### PR TITLE
Build now works for static extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ include(FetchContent)
 include(GNUInstallDirs)
 include(ExternalProject)
 
-option(BUILD_LOADABLE_EXTENSION "Build as loadable extension" ON)
-option(LOAD_TESTS "Build extension tests" OFF)
+option(BUILD_LOADABLE_EXTENSION "Build as loadable extension" OFF) # Does not work as for now
+option(LOAD_TESTS "Build extension tests" OFF) # Does not work as for now
 option(SHOW_LOG_STAGES "Display progress logs for each stage" ON)
 
 # # =============================================
@@ -36,28 +36,6 @@ endfunction()
 # =============================================
 # Dependency Management
 # =============================================
-# DuckDB
-set(DUCKDB_EXTENSION_CONFIGS "${CMAKE_CURRENT_SOURCE_DIR}/config/extension_config.cmake")
-
-log_stage("Declaring DuckDB")
-set(BUILD_UNITTESTS OFF CACHE BOOL "")
-set(ENABLE_SANITIZER OFF CACHE BOOL "")
-set(ENABLE_UBSAN OFF CACHE BOOL "")
-set(DISABLE_VPTR_SANITIZER ON CACHE BOOL "")
-set(SKIP_EXTENSIONS "graphar_duck")
-
-FetchContent_Declare(
-    duckdb
-    GIT_REPOSITORY https://github.com/duckdb/duckdb.git
-    GIT_TAG v1.3.2
-    GIT_SHALLOW TRUE
-    GIT_PROGRESS TRUE
-)
-log_done()
-
-log_stage("Making available")
-FetchContent_MakeAvailable(duckdb)
-log_done()
 
 # Arrow
 log_stage("Configuring Apache Arrow...")
@@ -78,8 +56,10 @@ ExternalProject_Add(
     -DARROW_COMPUTE=ON
     -DARROW_DATASET=ON
     -DARROW_FILESYSTEM=ON
+    -DARROW_S3=ON
     -DARROW_PARQUET=ON
     -DARROW_ORC=ON
+    -DARROW_JSON=ON
     -DARROW_WITH_ZLIB=ON
     -DARROW_WITH_ZSTD=ON
     -DARROW_WITH_BROTLI=OFF
@@ -94,8 +74,9 @@ ExternalProject_Add(
 
 add_library(arrow::arrow_shared SHARED IMPORTED GLOBAL)
 
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/arrow-install/include")
 set_target_properties(arrow::arrow_shared PROPERTIES
-  IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/arrow-install/lib/libarrow.so
+  IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/arrow-install/lib/libarrow${CMAKE_SHARED_LIBRARY_SUFFIX}"
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/arrow-install/include
 )
 
@@ -103,23 +84,19 @@ add_dependencies(arrow::arrow_shared arrow)
 
 # GraphAr
 
-set(Protobuf_INCLUDE_DIR "${CMAKE_BINARY_DIR}/duckdb-build/extension/${PROJECT_NAME}/arrow-prefix/src/arrow-build/protobuf_ep-install/include")
-set(Protobuf_LIBRARIES "${CMAKE_BINARY_DIR}/duckdb-build/extension/${PROJECT_NAME}/arrow-prefix/src/arrow-build/protobuf_ep-install/lib/libprotobuf.a")
-
 log_stage("Setting up GraphAR...")
 
 ExternalProject_Add(
   graphar
   GIT_REPOSITORY https://github.com/apache/incubator-graphar.git
-  GIT_TAG main
+  # GIT_TAG main
+  GIT_TAG 1a44bc343e0e846df129c78152f6310a1d678429
   SOURCE_SUBDIR cpp
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/graphar-install
     -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/arrow-install
-    -DARROW_HOME=${CMAKE_BINARY_DIR}/arrow-install
-    -DGRAPHAR_BUILD_SHARED=ON
-    -DGRAPHAR_BUILD_STATIC=OFF
-    -DGRAPHAR_TEST=OFF
+    -DProtobuf_INCLUDE_DIR=${CMAKE_BINARY_DIR}/arrow-prefix/src/arrow-build/protobuf_ep-install/include
+    -DProtobuf_LIBRARIES=${CMAKE_BINARY_DIR}/arrow-prefix/src/arrow-build/protobuf_ep-install/lib/libprotobuf.a
   INSTALL_DIR ${CMAKE_BINARY_DIR}/graphar-install
   DEPENDS arrow
 )
@@ -127,7 +104,7 @@ ExternalProject_Add(
 add_library(graphar::graphar_shared SHARED IMPORTED GLOBAL)
 
 set_target_properties(graphar::graphar_shared PROPERTIES
-  IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/graphar-install/lib/libgraphar.so
+  IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/graphar-install/lib/libgraphar${CMAKE_SHARED_LIBRARY_SUFFIX}"
   # INTERFACE_INCLUDE_DIRECTORIES ${graphar_SOURCE_DIR}/graphar-install/include
   INTERFACE_LINK_LIBRARIES arrow::arrow_shared
 )
@@ -136,44 +113,27 @@ add_dependencies(graphar::graphar_shared graphar arrow)
 
 log_done()
 
-# =============================================
-# Build Targets
-# =============================================
-file(GLOB_RECURSE EXTENSION_SOURCES CONFIGURE_DEPENDS "${EXTENSION_ROOT_DIR}/src/*.cpp")
+# DuckDB
+set(DUCKDB_EXTENSION_CONFIGS "${CMAKE_CURRENT_SOURCE_DIR}/config/extension_config.cmake")
 
-log_stage("Building static extension")
-build_static_extension(graphar_duck ${EXTENSION_SOURCES})
+log_stage("Declaring DuckDB")
+set(BUILD_UNITTESTS OFF CACHE BOOL "")
+set(ENABLE_SANITIZER OFF CACHE BOOL "")
+set(ENABLE_UBSAN OFF CACHE BOOL "")
+set(DISABLE_VPTR_SANITIZER ON CACHE BOOL "")
+# set(SKIP_EXTENSIONS "graphar_duck")
+
+FetchContent_Declare(
+    duckdb
+    GIT_REPOSITORY https://github.com/duckdb/duckdb.git
+    GIT_TAG v1.3.2
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+)
 log_done()
 
-set(EXTENSION_INCLUDES
-     $<BUILD_INTERFACE:${EXTENSION_ROOT_DIR}/include>
-    $<BUILD_INTERFACE:${graphar_SOURCE_DIR}/cpp/thirdparty>  # GraphAr thirdparty
-    $<BUILD_INTERFACE:${graphar_SOURCE_DIR}/cpp/src>  # GraphAr main includes (?)
-    $<BUILD_INTERFACE:${graphar_BINARY_DIR}/cpp/src>
-     $<BUILD_INTERFACE:${duckdb_SOURCE_DIR}/src/include>  # DuckDB internal (?)
-    $<BUILD_INTERFACE:${arrow_SOURCE_DIR}/cpp/src>  # Arrow main includes (?)
-    $<BUILD_INTERFACE:${arrow_BINARY_DIR}/cpp/src>  # Generated Arrow headers (?)
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-)
-target_include_directories(graphar_duck_extension PUBLIC ${EXTENSION_INCLUDES} $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+log_stage("Building DuckDB")
+FetchContent_MakeAvailable(duckdb)
+log_done()
 
-target_link_libraries(graphar_duck_extension
-    duckdb_static
-    arrow::arrow_shared
-    graphar::graphar_shared
-)
-
-# =============================================
-# Installation
-# =============================================
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Library installation directory")
-
-install(
-  TARGETS graphar_duck_extension
-  EXPORT "${DUCKDB_EXPORT_SET}"
-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
-
-install(DIRECTORY include/ DESTINATION include
-    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
-)
+# The rest is in config/CMakeLists.txt

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,68 @@
+# =============================================
+# Build Targets
+# =============================================
+
+file(GLOB_RECURSE EXTENSION_SOURCES CONFIGURE_DEPENDS "${EXTENSION_ROOT_DIR}/src/*.cpp")
+
+log_stage("Building static extension")
+build_static_extension(graphar_duck ${EXTENSION_SOURCES})
+log_done()
+
+if (BUILD_LOADABLE_EXTENSION)
+    log_stage("Building loadable extension")
+    build_loadable_extension(graphar_duck ${EXTENSION_SOURCES})
+    log_done()
+endif()
+
+set(graphar_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/graphar-src")
+set(arrow_SOURCE_DIR "${CMAKE_BINARY_DIR}/_deps/arrow-src")
+
+set(EXTENSION_INCLUDES
+     $<BUILD_INTERFACE:${EXTENSION_ROOT_DIR}/include>
+    $<BUILD_INTERFACE:${graphar_SOURCE_DIR}/cpp/thirdparty>  # GraphAr thirdparty
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/graphar-install/include>  # GraphAr main includes (?)
+    # $<BUILD_INTERFACE:${graphar_BINARY_DIR}/cpp/src>
+     $<BUILD_INTERFACE:${duckdb_SOURCE_DIR}/src/include>  # DuckDB internal (?)
+    $<BUILD_INTERFACE:${arrow_SOURCE_DIR}/cpp/src>  # Arrow main includes (?)
+    $<BUILD_INTERFACE:${arrow_BINARY_DIR}/cpp/src>  # Generated Arrow headers (?)
+    # $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+target_include_directories(graphar_duck_extension PUBLIC ${EXTENSION_INCLUDES} $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories(graphar_duck_loadable_extension PUBLIC ${EXTENSION_INCLUDES} $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_link_libraries(graphar_duck_extension
+    duckdb_static
+    arrow::arrow_shared
+    graphar::graphar_shared
+)
+
+if (BUILD_LOADABLE_EXTENSION)
+    target_link_libraries(graphar_duck_loadable_extension
+        arrow::arrow_shared
+        graphar::graphar_shared
+    )
+endif()
+
+# =============================================
+# Installation
+# =============================================
+log_stage("Installing...")
+set(INSTALL_LIB_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Library installation directory")
+
+install(
+  TARGETS graphar_duck_extension
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+
+if(BUILD_LOADABLE_EXTENSION)
+    install(TARGETS graphar_duck_loadable_extension
+        LIBRARY DESTINATION ${INSTALL_LIB_DIR}
+    )
+endif()
+
+install(DIRECTORY include/ DESTINATION include
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+
+log_done()

--- a/src/storage/graphar_table_entry.cpp
+++ b/src/storage/graphar_table_entry.cpp
@@ -1,6 +1,7 @@
 #include "utils/global_log_manager.hpp"
 
 #include "storage/graphar_table_entry.hpp"
+#include "storage/graphar_table_information.hpp"
 
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/table_storage_info.hpp"

--- a/src/utils/func.cpp
+++ b/src/utils/func.cpp
@@ -57,7 +57,6 @@ std::string GraphArFunctions::GetNameFromInfo(const std::shared_ptr<graphar::Edg
 	return info->GetSrcType() + "_" + info->GetEdgeType() + "_" + info->GetDstType() + ".edge";
 }
 
-<<<<<<< HEAD
 std::shared_ptr<graphar::Expression> GraphArFunctions::GetFilter(const std::string filter_type, const std::string filter_value, const std::string filter_column) {
 	if (filter_type == "string") {
 		return graphar::_Equal(graphar::_Property(filter_column),
@@ -73,26 +72,6 @@ std::shared_ptr<graphar::Expression> GraphArFunctions::GetFilter(const std::stri
 		return graphar::_Equal(graphar::_Property(filter_column), graphar::_Literal(std::stod(filter_value)));
 	}
 	throw NotImplementedException("Unsupported filter type");
-=======
-std::shared_ptr<graphar::Expression> GraphArFunctions::GetFilter(const std::string filter_type,
-                                                                 const std::string filter_value,
-                                                                 const std::string filter_column) {
-    if (filter_type == "string") {
-        return graphar::_Equal(graphar::_Property(filter_column),
-                               graphar::_Literal(filter_value.substr(1, filter_value.size() - 2)));
-    } else if (filter_type == "int32") {
-        return graphar::_Equal(graphar::_Property(filter_column), graphar::_Literal(std::stoi(filter_value)));
-    } else if (filter_type == "int64") {
-        // Bug: stoll -> long long int, need only int64_t == long long
-        return graphar::_Equal(graphar::_Property(filter_column),
-                               graphar::_Literal((int64_t)(std::stoll(filter_value))));
-    } else if (filter_type == "float") {
-        return graphar::_Equal(graphar::_Property(filter_column), graphar::_Literal(std::stof(filter_value)));
-    } else if (filter_type == "double") {
-        return graphar::_Equal(graphar::_Property(filter_column), graphar::_Literal(std::stod(filter_value)));
-    }
-    throw NotImplementedException("Unsupported filter type");
->>>>>>> upstream/main
 }
 
 std::string GetYamlContent(const std::string &path) {


### PR DESCRIPTION
Now an extension linked into duckdb binary can be built. Loadable extension and tests are not supported.