### PR TITLE
fit(reading): Add batch one-hop functionality and fix chunks order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Suppress all warnings
-add_compile_options(-w)
-
 if(UNIX AND NOT APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Suppress all warnings
+add_compile_options(-w)
+
 if(UNIX AND NOT APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")

--- a/config/test/sql/graphar/batch_onehop.test
+++ b/config/test/sql/graphar/batch_onehop.test
@@ -297,3 +297,8 @@ query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37698, 37699, 37700];
 ----
 2
+
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN (0, 1) AND _graphArDstIndex IN (23977, 34526);
+----
+2

--- a/config/test/sql/graphar/batch_onehop.test
+++ b/config/test/sql/graphar/batch_onehop.test
@@ -1,0 +1,299 @@
+require duckdb_graphar
+
+statement ok
+SET autoinstall_known_extensions=1;
+
+statement ok
+SET autoload_known_extensions=1;
+
+# ============================================================================
+# Batch One-Hop Functionality Tests
+# Tests for filtering over _graphArVertexIndex, _graphArSrcIndex, _graphArDstIndex
+# with multiple filters in one query
+# ============================================================================
+
+# Attach the test database
+statement ok
+ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+
+# ============================================================================
+# VERTEX TESTS (_graphArVertexIndex)
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Bug 1: Duplicate values in IN clause
+# ----------------------------------------------------------------------------
+# Test: SELECT id FROM Person WHERE _graphArVertexIndex IN [5, 5]
+# Expected: Should return only one row with id=5 (duplicates should be handled)
+query I
+SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [5, 5];
+----
+5
+
+# Test with multiple duplicates
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [10, 10, 10, 10];
+----
+1
+
+# ----------------------------------------------------------------------------
+# Bug 2: Negative values in IN clause
+# ----------------------------------------------------------------------------
+# Test: SELECT COUNT(*) FROM Person WHERE _graphArVertexIndex IN [-1, 5]
+# Expected: Should handle negative values gracefully (filter them out)
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [-1, 5];
+----
+1
+
+# Test with only negative values
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [-10, -5, -1];
+----
+0
+
+# Test with mix of negative and positive
+query I
+SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [-3, 0, 3] ORDER BY id;
+----
+0
+3
+
+# ----------------------------------------------------------------------------
+# Bug 2: Out-of-range values in IN clause
+# ----------------------------------------------------------------------------
+# Test: SELECT COUNT(*) FROM Person WHERE _graphArVertexIndex IN [37700, 5]
+# Expected: 37700 is out of range (valid range is 0-37699), should return only id=5
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37700, 5];
+----
+1
+
+# Test with only out-of-range values
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37700, 37701, 37702];
+----
+0
+
+# Test with multiple out-of-range and valid values
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37699, 37700, 0, 50000];
+----
+2
+
+# ----------------------------------------------------------------------------
+# Multiple filters with AND operator (intersection)
+# ----------------------------------------------------------------------------
+# Test: SELECT id FROM Person WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [2, 3]
+# Expected: Should return only id=2 (intersection of both conditions)
+query I
+SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [2, 3];
+----
+2
+
+# Test with no intersection
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [5, 6];
+----
+0
+
+# Test with multiple AND conditions
+query I
+SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2] AND _graphArVertexIndex IN [1, 2, 3] AND _graphArVertexIndex IN [2, 3, 4];
+----
+2
+
+# ----------------------------------------------------------------------------
+# Edge cases: Empty result sets
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [999999];
+----
+0
+
+# ----------------------------------------------------------------------------
+# Edge cases: Large number of values in IN clause
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+----
+20
+
+# ============================================================================
+# EDGE TESTS (_graphArSrcIndex)
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Bug 1: Duplicate values in IN clause for edges
+# ----------------------------------------------------------------------------
+# src_index=1 has 8 edges (verified earlier)
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 1];
+----
+8
+
+# Test with multiple duplicates - src_index=5 has 1 edge
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [5, 5, 5, 5];
+----
+1
+
+# ----------------------------------------------------------------------------
+# Bug 2: Negative values in IN clause for edges
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-1, 5];
+----
+1
+
+# Test with only negative values
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-10, -5, -1];
+----
+0
+
+# Test with mix of negative and positive - src_index=0 has 1 edge, src_index=3 has 5 edges
+query II
+SELECT _graphArSrcIndex, _graphArDstIndex FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-3, 0, 3] ORDER BY _graphArSrcIndex, _graphArDstIndex;
+----
+0	23977
+3	3358
+3	4950
+3	5916
+3	18029
+3	34935
+
+# ----------------------------------------------------------------------------
+# Bug 2: Out-of-range values in IN clause for edges
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [37700, 5];
+----
+1
+
+# Test with only out-of-range values
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [37700, 37701, 37702];
+----
+0
+
+# ----------------------------------------------------------------------------
+# Multiple filters with AND operator for edges (intersection)
+# ----------------------------------------------------------------------------
+# src_index=1 has 8 edges, src_index=2 has 1 edge, src_index=3 has 5 edges
+# Intersection of [1,2] AND [2,3] should give only src_index=2 (1 edge)
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 2] AND _graphArSrcIndex IN [2, 3];
+----
+1
+
+# Test with no intersection
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 2] AND _graphArSrcIndex IN [100, 101];
+----
+0
+
+# ============================================================================
+# EDGE TESTS (_graphArDstIndex)
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Bug 1: Duplicate values in IN clause for dst index
+# ----------------------------------------------------------------------------
+# dst_index=23977 appears 23 times (verified earlier)
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [23977, 23977];
+----
+23
+
+# Test with multiple duplicates - dst_index=3358 appears 4 times
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [3358, 3358, 3358];
+----
+4
+
+# ----------------------------------------------------------------------------
+# Bug 2: Negative values in IN clause for dst index
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [-1, 23977];
+----
+23
+
+# Test with only negative values
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [-10, -5, -1];
+----
+0
+
+# ----------------------------------------------------------------------------
+# Bug 2: Out-of-range values in IN clause for dst index
+# ----------------------------------------------------------------------------
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [999999, 23977];
+----
+23
+
+# Test with only out-of-range values
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [999999, 999998];
+----
+0
+
+# ----------------------------------------------------------------------------
+# Multiple filters with AND operator for dst index (intersection)
+# ----------------------------------------------------------------------------
+# dst_index=23977 appears 23 times, dst_index=3358 appears 4 times
+# Intersection of [23977, 3358] AND [3358, 4950] should give only dst_index=3358 (4 edges)
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [23977, 3358] AND _graphArDstIndex IN [3358, 4950];
+----
+4
+
+# ============================================================================
+# COMBINED FILTER TESTS
+# ============================================================================
+
+# Test filtering by both src and dst (should use only one filter pushdown)
+# src_index=0 has 1 edge (to 23977), src_index=1 has 8 edges
+# After filtering by src IN [0,1], we apply dst IN [23977, 34526]
+# dst=23977 from src=0 matches, dst=34526 from src=1 matches
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1] AND _graphArDstIndex IN [23977, 34526];
+----
+2
+
+# Test vertex filter with property filter
+# vertex 0: ml_target=false, vertex 1: ml_target=false, vertex 2: ml_target=true
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2] AND ml_target = true;
+----
+1
+
+# Test edge filter - src_index=0 has 1 edge, src_index=1 has 8 edges
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1];
+----
+9
+
+# ============================================================================
+# EDGE CASES: Boundary values
+# ============================================================================
+
+# Test boundary: first valid index
+query I
+SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [0];
+----
+0
+
+# Test boundary: last valid index (37699 based on COUNT(*) = 37700)
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37699];
+----
+1
+
+# Test boundary: just before invalid range
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37698, 37699, 37700];
+----
+2

--- a/config/test/sql/graphar/batch_onehop.test
+++ b/config/test/sql/graphar/batch_onehop.test
@@ -6,153 +6,95 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
-# ============================================================================
-# Batch One-Hop Functionality Tests
-# Tests for filtering over _graphArVertexIndex, _graphArSrcIndex, _graphArDstIndex
-# with multiple filters in one query
-# ============================================================================
-
-# Attach the test database
 statement ok
 ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
-# ============================================================================
-# VERTEX TESTS (_graphArVertexIndex)
-# ============================================================================
-
-# ----------------------------------------------------------------------------
-# Bug 1: Duplicate values in IN clause
-# ----------------------------------------------------------------------------
-# Test: SELECT id FROM Person WHERE _graphArVertexIndex IN [5, 5]
-# Expected: Should return only one row with id=5 (duplicates should be handled)
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [5, 5];
 ----
 5
 
-# Test with multiple duplicates
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [10, 10, 10, 10];
 ----
 1
 
-# ----------------------------------------------------------------------------
-# Bug 2: Negative values in IN clause
-# ----------------------------------------------------------------------------
-# Test: SELECT COUNT(*) FROM Person WHERE _graphArVertexIndex IN [-1, 5]
-# Expected: Should handle negative values gracefully (filter them out)
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [-1, 5];
 ----
 1
 
-# Test with only negative values
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [-10, -5, -1];
 ----
 0
 
-# Test with mix of negative and positive
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [-3, 0, 3] ORDER BY id;
 ----
 0
 3
 
-# ----------------------------------------------------------------------------
-# Bug 2: Out-of-range values in IN clause
-# ----------------------------------------------------------------------------
-# Test: SELECT COUNT(*) FROM Person WHERE _graphArVertexIndex IN [37700, 5]
-# Expected: 37700 is out of range (valid range is 0-37699), should return only id=5
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37700, 5];
 ----
 1
 
-# Test with only out-of-range values
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37700, 37701, 37702];
 ----
 0
 
-# Test with multiple out-of-range and valid values
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37699, 37700, 0, 50000];
 ----
 2
 
-# ----------------------------------------------------------------------------
-# Multiple filters with AND operator (intersection)
-# ----------------------------------------------------------------------------
-# Test: SELECT id FROM Person WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [2, 3]
-# Expected: Should return only id=2 (intersection of both conditions)
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [2, 3];
 ----
 2
 
-# Test with no intersection
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [1, 2] AND _graphArVertexIndex IN [5, 6];
 ----
 0
 
-# Test with multiple AND conditions
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2] AND _graphArVertexIndex IN [1, 2, 3] AND _graphArVertexIndex IN [2, 3, 4];
 ----
 2
 
-# ----------------------------------------------------------------------------
-# Edge cases: Empty result sets
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [999999];
 ----
 0
 
-# ----------------------------------------------------------------------------
-# Edge cases: Large number of values in IN clause
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
 ----
 20
 
-# ============================================================================
-# EDGE TESTS (_graphArSrcIndex)
-# ============================================================================
-
-# ----------------------------------------------------------------------------
-# Bug 1: Duplicate values in IN clause for edges
-# ----------------------------------------------------------------------------
-# src_index=1 has 8 edges (verified earlier)
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 1];
 ----
 8
 
-# Test with multiple duplicates - src_index=5 has 1 edge
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [5, 5, 5, 5];
 ----
 1
 
-# ----------------------------------------------------------------------------
-# Bug 2: Negative values in IN clause for edges
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-1, 5];
 ----
 1
 
-# Test with only negative values
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-10, -5, -1];
 ----
 0
 
-# Test with mix of negative and positive - src_index=0 has 1 edge, src_index=3 has 5 edges
 query II
 SELECT _graphArSrcIndex, _graphArDstIndex FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [-3, 0, 3] ORDER BY _graphArSrcIndex, _graphArDstIndex;
 ----
@@ -163,136 +105,86 @@ SELECT _graphArSrcIndex, _graphArDstIndex FROM 'Person_knows_Person' WHERE _grap
 3	18029
 3	34935
 
-# ----------------------------------------------------------------------------
-# Bug 2: Out-of-range values in IN clause for edges
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [37700, 5];
 ----
 1
 
-# Test with only out-of-range values
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [37700, 37701, 37702];
 ----
 0
 
-# ----------------------------------------------------------------------------
-# Multiple filters with AND operator for edges (intersection)
-# ----------------------------------------------------------------------------
-# src_index=1 has 8 edges, src_index=2 has 1 edge, src_index=3 has 5 edges
-# Intersection of [1,2] AND [2,3] should give only src_index=2 (1 edge)
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 2] AND _graphArSrcIndex IN [2, 3];
 ----
 1
 
-# Test with no intersection
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [1, 2] AND _graphArSrcIndex IN [100, 101];
 ----
 0
 
-# ============================================================================
-# EDGE TESTS (_graphArDstIndex)
-# ============================================================================
-
-# ----------------------------------------------------------------------------
-# Bug 1: Duplicate values in IN clause for dst index
-# ----------------------------------------------------------------------------
-# dst_index=23977 appears 23 times (verified earlier)
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [23977, 23977];
 ----
 23
 
-# Test with multiple duplicates - dst_index=3358 appears 4 times
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [3358, 3358, 3358];
 ----
 4
 
-# ----------------------------------------------------------------------------
-# Bug 2: Negative values in IN clause for dst index
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [-1, 23977];
 ----
 23
 
-# Test with only negative values
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [-10, -5, -1];
 ----
 0
 
-# ----------------------------------------------------------------------------
-# Bug 2: Out-of-range values in IN clause for dst index
-# ----------------------------------------------------------------------------
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [999999, 23977];
 ----
 23
 
-# Test with only out-of-range values
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [999999, 999998];
 ----
 0
 
-# ----------------------------------------------------------------------------
-# Multiple filters with AND operator for dst index (intersection)
-# ----------------------------------------------------------------------------
-# dst_index=23977 appears 23 times, dst_index=3358 appears 4 times
-# Intersection of [23977, 3358] AND [3358, 4950] should give only dst_index=3358 (4 edges)
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArDstIndex IN [23977, 3358] AND _graphArDstIndex IN [3358, 4950];
 ----
 4
 
-# ============================================================================
-# COMBINED FILTER TESTS
-# ============================================================================
-
-# Test filtering by both src and dst (should use only one filter pushdown)
-# src_index=0 has 1 edge (to 23977), src_index=1 has 8 edges
-# After filtering by src IN [0,1], we apply dst IN [23977, 34526]
-# dst=23977 from src=0 matches, dst=34526 from src=1 matches
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1] AND _graphArDstIndex IN [23977, 34526];
 ----
 2
 
-# Test vertex filter with property filter
-# vertex 0: ml_target=false, vertex 1: ml_target=false, vertex 2: ml_target=true
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2] AND ml_target = true;
 ----
 1
 
-# Test edge filter - src_index=0 has 1 edge, src_index=1 has 8 edges
 query I
 SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1];
 ----
 9
 
-# ============================================================================
-# EDGE CASES: Boundary values
-# ============================================================================
-
-# Test boundary: first valid index
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [0];
 ----
 0
 
-# Test boundary: last valid index (37699 based on COUNT(*) = 37700)
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37699];
 ----
 1
 
-# Test boundary: just before invalid range
 query I
 SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [37698, 37699, 37700];
 ----

--- a/config/test/sql/graphar/read_edges.test
+++ b/config/test/sql/graphar/read_edges.test
@@ -43,3 +43,26 @@ query I
 SELECT COUNT(*) FROM 'Person_knows_Person';
 ----
 289003
+
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1, 2, 3];
+----
+15
+
+query II
+SELECT _graphArSrcIndex, _graphArDstIndex FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1] ORDER BY _graphArSrcIndex, _graphArDstIndex;
+----
+0	23977
+1	2370
+1	14683
+1	20363
+1	21142
+1	23830
+1	29982
+1	34035
+1	34526
+
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [100, 11];
+----
+2

--- a/config/test/sql/graphar/read_edges_csv.test
+++ b/config/test/sql/graphar/read_edges_csv.test
@@ -43,3 +43,26 @@ query I
 SELECT COUNT(*) FROM 'Person_knows_Person';
 ----
 289003
+
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1, 2, 3];
+----
+15
+
+query II
+SELECT _graphArSrcIndex, _graphArDstIndex FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [0, 1] ORDER BY _graphArSrcIndex, _graphArDstIndex;
+----
+0	23977
+1	2370
+1	14683
+1	20363
+1	21142
+1	23830
+1	29982
+1	34035
+1	34526
+
+query I
+SELECT COUNT(*) FROM 'Person_knows_Person' WHERE _graphArSrcIndex IN [100, 11];
+----
+2

--- a/config/test/sql/graphar/read_vertices.test
+++ b/config/test/sql/graphar/read_vertices.test
@@ -41,3 +41,19 @@ query I
 SELECT COUNT(*) FROM 'Person';
 ----
 37700
+
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2, 3];
+----
+4
+
+query II
+SELECT id, _graphArVertexIndex FROM 'Person' WHERE _graphArVertexIndex IN [0, 1] ORDER BY _graphArVertexIndex;
+----
+0	0
+1	1
+
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [100, 11, 5];
+----
+3

--- a/config/test/sql/graphar/read_vertices_csv.test
+++ b/config/test/sql/graphar/read_vertices_csv.test
@@ -41,3 +41,19 @@ query I
 SELECT COUNT(*) FROM 'Person';
 ----
 37700
+
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [0, 1, 2, 3];
+----
+4
+
+query II
+SELECT id, _graphArVertexIndex FROM 'Person' WHERE _graphArVertexIndex IN [0, 1] ORDER BY _graphArVertexIndex;
+----
+0	0
+1	1
+
+query I
+SELECT COUNT(*) FROM 'Person' WHERE _graphArVertexIndex IN [100, 11, 5];
+----
+3

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -43,11 +43,12 @@ using ReaderPtr = std::variant<
     std::shared_ptr<graphar::DuckAdjListPropertyChunkReader>>;
 
 template <typename SomeReader>
-BaseReaderPtr ConvertBaseReader(graphar::Result<std::shared_ptr<SomeReader>> maybe_reader) {
+BaseReaderPtr ConvertBaseReader(graphar::Result<std::shared_ptr<SomeReader>> maybe_reader,
+                                std::shared_ptr<graphar::SharedChunkCounter> counter = nullptr) {
     if (maybe_reader.has_error()) {
         throw InternalException("Error converting reader: " + maybe_reader.error().message());
     }
-    return std::make_shared<graphar::ThreadSafeReader<SomeReader>>(std::move(maybe_reader.value()));
+    return std::make_shared<graphar::ThreadSafeReader<SomeReader>>(std::move(maybe_reader.value()), counter);
 }
 
 template <typename SomeReader>
@@ -140,7 +141,7 @@ private:
     idx_t id_columns_num = 0;
     idx_t pg_for_id = 0;
 
-    std::pair<graphar::IdType, graphar::IdType> vid_range = {-1, -1};
+    vector<std::pair<graphar::IdType, graphar::IdType>> vid_ranges;
     std::string filter_column;
 
     TypeInfoPtr type_info;
@@ -162,7 +163,7 @@ private:
     vector<vector<std::string>> prop_types;
     std::atomic<idx_t> chunk_count = 0;
     idx_t total_props_num = 0;
-    vector<BaseReaderPtr> base_readers;
+    vector<vector<BaseReaderPtr>> base_readers;
 
     TypeInfoPtr type_info;
     std::shared_ptr<graphar::GraphInfo> graph_info;
@@ -267,18 +268,23 @@ public:
     }
 
     static BaseReaderPtr GetBaseReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                                       const std::string& filter_column) {
-        return ReadFinal::GetBaseReader(context, gstate, ind, filter_column);
+                                       const std::string& filter_column,
+                                       std::shared_ptr<graphar::SharedChunkCounter> counter = nullptr) {
+        return ReadFinal::GetBaseReader(context, gstate, ind, filter_column, counter);
     }
 
     static void SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                          const std::pair<int64_t, int64_t>& vid_range, const std::string& filter_column) {
-        return ReadFinal::SetFilter(context, gstate, ind, vid_range, filter_column);
+                          const vector<std::pair<int64_t, int64_t>>& vid_ranges, const std::string& filter_column) {
+        return ReadFinal::SetFilter(context, gstate, ind, vid_ranges, filter_column);
     }
 
     static ReaderPtr GetReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate,
                                ReadBaseLocalTableFunctionState& lstate, idx_t ind, const std::string& filter_column) {
         return ReadFinal::GetReader(context, gstate, lstate, ind, filter_column);
+    }
+
+    static const vector<std::pair<graphar::IdType, graphar::IdType>>& GetVidRanges(const ReadBindData& bind_data) {
+        return bind_data.vid_ranges;
     }
 
     static unique_ptr<GlobalTableFunctionState> Init(ClientContext& context, TableFunctionInitInput& input) {
@@ -323,11 +329,20 @@ public:
         vector<vector<column_t>> local_projected_inds(prop_types_size);
         gstate.global_projected_inds.resize(prop_types_size);
         gstate.base_readers.resize(prop_types_size);
+
+        auto& vid_ranges = bind_data.vid_ranges;
+        const bool has_filter = filter_column != "" && !vid_ranges.empty();
+        const idx_t num_ranges = has_filter ? vid_ranges.size() : 1;
+
         if (gstate.column_ids.empty() ||
             gstate.column_ids.size() == 1 && gstate.column_ids[0] == COLUMN_IDENTIFIER_ROW_ID) {
             DUCKDB_GRAPHAR_LOG_DEBUG("Returning any column");
             local_projected_inds[0].emplace_back(0);
-            gstate.base_readers[0] = GetBaseReader(context, gstate, 0, filter_column);
+            gstate.base_readers[0].resize(num_ranges);
+            auto counter = has_filter ? std::make_shared<graphar::SharedChunkCounter>() : nullptr;
+            for (idx_t r = 0; r < num_ranges; ++r) {
+                gstate.base_readers[0][r] = GetBaseReader(context, gstate, 0, filter_column, counter);
+            }
             gstate.global_projected_inds[0].emplace_back(0);
         } else {
             DUCKDB_GRAPHAR_LOG_DEBUG("Returning specific columns");
@@ -347,28 +362,33 @@ public:
                 if (local_projected_inds[i].empty()) {
                     continue;
                 }
-                gstate.base_readers[i] = std::move(GetBaseReader(context, gstate, i, filter_column));
+                gstate.base_readers[i].resize(num_ranges);
+                auto counter = has_filter ? std::make_shared<graphar::SharedChunkCounter>() : nullptr;
+                for (idx_t r = 0; r < num_ranges; ++r) {
+                    gstate.base_readers[i][r] = GetBaseReader(context, gstate, i, filter_column, counter);
+                }
             }
         }
 
         DUCKDB_GRAPHAR_LOG_DEBUG("readers num: " + std::to_string(gstate.base_readers.size()));
 
-        if (filter_column != "") {
+        if (has_filter) {
             DUCKDB_GRAPHAR_LOG_TRACE("Filters found");
-            auto vid_range = bind_data.vid_range;
             const auto vertex_num = GetCountClass::GetCount(gstate.type_info, bind_data.GetGraphInfo()->GetPrefix());
             graphar::IdType zero = 0;
-            vid_range.first = std::max(zero, vid_range.first);
-            vid_range.second = std::min(vertex_num, vid_range.second);
-            if (vid_range.first >= vid_range.second) {
-                throw IOException("Invalid filter range: " + std::to_string(vid_range.first) + " > " +
-                                  std::to_string(vid_range.second));
+            for (idx_t r = 0; r < num_ranges; ++r) {
+                vid_ranges[r].first = std::max(zero, vid_ranges[r].first);
+                vid_ranges[r].second = std::min(vertex_num, vid_ranges[r].second);
+                if (vid_ranges[r].first >= vid_ranges[r].second) {
+                    throw IOException("Invalid filter range: " + std::to_string(vid_ranges[r].first) + " > " +
+                                      std::to_string(vid_ranges[r].second));
+                }
             }
             for (idx_t ind = 0; ind < prop_types_size; ++ind) {
-                if (IsNullPtr(gstate.base_readers[ind])) {
+                if (gstate.base_readers[ind].empty() || IsNullPtr(gstate.base_readers[ind][0])) {
                     continue;
                 }
-                SetFilter(context, gstate, ind, vid_range, filter_column);
+                SetFilter(context, gstate, ind, vid_ranges, filter_column);
             }
         }
         if (time_logging) {
@@ -461,8 +481,8 @@ public:
     static void Register(ExtensionLoader& loader) { loader.RegisterFunction(ReadFinal::GetFunction()); }
     static TableFunction GetFunction() { return ReadFinal::GetFunction(); }
     static TableFunction GetScanFunction() { return ReadFinal::GetScanFunction(); }
-    static OperatorPartitionData GetPartitionData(ClientContext &context, TableFunctionGetPartitionInput &input) {
-        auto &lstate = input.local_state->Cast<ReadBaseLocalTableFunctionState>();
+    static OperatorPartitionData GetPartitionData(ClientContext& context, TableFunctionGetPartitionInput& input) {
+        auto& lstate = input.local_state->Cast<ReadBaseLocalTableFunctionState>();
         return OperatorPartitionData(lstate.cur_chunk_id);
     }
 };

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -488,7 +488,7 @@ public:
                 }
                 auto gc_result_final = GetChunk(lstate.readers[i], num_rows);
                 lstate.cur_chunks[i] = std::move(gc_result_final.first);
-                
+
                 if (!chunk_id_set) {
                     lstate.cur_chunk_id = gc_result_final.second;
                     chunk_id_set = true;
@@ -542,30 +542,30 @@ public:
 
             bool can_pushdown = false;
 
-            // Case 0: equality comparison (col = value)  
-            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {  
-                auto& comparison = filter->Cast<BoundComparisonExpression>();  
-                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {  
-                    bool left_is_scalar = comparison.left->IsFoldable();  
-                    bool right_is_scalar = comparison.right->IsFoldable();  
-                    if (left_is_scalar || right_is_scalar) {  
-                        auto column_name = comparison.left->ToString();  
-                        Value val;  
-                        
-                        auto& scalar_expr = (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)   
-                                        ? *comparison.right   
-                                        : *comparison.left;  
-                        
+            // Case 0: equality comparison (col = value)
+            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+                auto& comparison = filter->Cast<BoundComparisonExpression>();
+                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
+                    bool left_is_scalar = comparison.left->IsFoldable();
+                    bool right_is_scalar = comparison.right->IsFoldable();
+                    if (left_is_scalar || right_is_scalar) {
+                        auto column_name = comparison.left->ToString();
+                        Value val;
+
+                        auto& scalar_expr = (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)
+                                                ? *comparison.right
+                                                : *comparison.left;
+
                         if (!ExpressionExecutor::TryEvaluateScalar(context, scalar_expr, val)) {
                             continue;
-                        }  
-                        
-                        if (validate_wrapper(column_name, val)) {  
-                            can_pushdown = true;  
-                            read_bind_data.filter_column = column_name;  
-                        }  
-                    }  
-                }  
+                        }
+
+                        if (validate_wrapper(column_name, val)) {
+                            can_pushdown = true;
+                            read_bind_data.filter_column = column_name;
+                        }
+                    }
+                }
             }
 
             // Case 1: list_contains([1, 2, 3], col) -- list literal

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -481,13 +481,21 @@ public:
         DUCKDB_GRAPHAR_LOG_DEBUG("num rows final: " + std::to_string(num_rows));
 
         if (num_rows > 0) {
+            bool chunk_id_set = false;
             for (idx_t i = 0; i < lstate.readers.size(); i++) {
                 if (IsNullPtr(lstate.readers[i])) {
                     continue;
                 }
                 auto gc_result_final = GetChunk(lstate.readers[i], num_rows);
                 lstate.cur_chunks[i] = std::move(gc_result_final.first);
-                lstate.cur_chunk_id = gc_result_final.second;
+                
+                if (!chunk_id_set) {
+                    lstate.cur_chunk_id = gc_result_final.second;
+                    chunk_id_set = true;
+                } else if (lstate.cur_chunk_id != gc_result_final.second) {
+                    throw InternalException("Desynchronization error: Property Groups returned different chunk IDs!");
+                }
+
                 for (idx_t j = 0; j < lstate.cur_chunks[i]->ColumnCount(); j++) {
                     output.data[gstate.global_projected_inds[i][j]].Reference(lstate.cur_chunks[i]->data[j]);
                 }
@@ -517,10 +525,13 @@ public:
 
         // Wrapper lambda that captures vids by reference
         auto validate_wrapper = [&](const std::string& col, const Value& val) -> bool {
-            if (!val.IsNull()) {
-                vids.insert(val.GetValue<int64_t>());
+            if (validate_and_extract(col, val)) {
+                if (!val.IsNull()) {
+                    vids.insert(val.GetValue<int64_t>());
+                }
+                return true;
             }
-            return validate_and_extract(col, val);
+            return false;
         };
 
         for (auto& filter : filters) {
@@ -531,26 +542,30 @@ public:
 
             bool can_pushdown = false;
 
-            // Case 0: equality comparison (col = value)
-            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-                auto& comparison = filter->Cast<BoundComparisonExpression>();
-                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
-                    bool left_is_scalar = comparison.left->IsFoldable();
-                    bool right_is_scalar = comparison.right->IsFoldable();
-                    if (left_is_scalar || right_is_scalar) {
-                        auto column_name = comparison.left->ToString();
-                        Value val;
-                        if (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-                            val = comparison.right->Cast<BoundConstantExpression>().value;
-                        } else {
-                            val = comparison.left->Cast<BoundConstantExpression>().value;
-                        }
-                        if (validate_wrapper(column_name, val)) {
-                            can_pushdown = true;
-                            read_bind_data.filter_column = column_name;
-                        }
-                    }
-                }
+            // Case 0: equality comparison (col = value)  
+            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {  
+                auto& comparison = filter->Cast<BoundComparisonExpression>();  
+                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {  
+                    bool left_is_scalar = comparison.left->IsFoldable();  
+                    bool right_is_scalar = comparison.right->IsFoldable();  
+                    if (left_is_scalar || right_is_scalar) {  
+                        auto column_name = comparison.left->ToString();  
+                        Value val;  
+                        
+                        auto& scalar_expr = (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)   
+                                        ? *comparison.right   
+                                        : *comparison.left;  
+                        
+                        if (!ExpressionExecutor::TryEvaluateScalar(context, scalar_expr, val)) {
+                            continue;
+                        }  
+                        
+                        if (validate_wrapper(column_name, val)) {  
+                            can_pushdown = true;  
+                            read_bind_data.filter_column = column_name;  
+                        }  
+                    }  
+                }  
             }
 
             // Case 1: list_contains([1, 2, 3], col) -- list literal

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -58,10 +58,10 @@ ReaderPtr ConvertReader(graphar::Result<std::shared_ptr<SomeReader>> maybe_reade
     return maybe_reader.value();
 }
 
-static unique_ptr<DataChunk> GetChunk(ReaderPtr& reader, int64_t num_rows) {
+static graphar::GetChunkFinalResult GetChunk(ReaderPtr& reader, int64_t num_rows) {
     DUCKDB_GRAPHAR_LOG_TRACE("GetChunk");
     return std::visit(
-        [&num_rows](auto& r) {
+        [&num_rows](auto& r) -> graphar::GetChunkFinalResult {
             auto maybe_chunk = r->GetChunk(num_rows);
             if (maybe_chunk.has_error()) {
                 throw InternalException("Error getting chunk: " + maybe_chunk.status().message());
@@ -187,6 +187,7 @@ private:
     vector<ReaderPtr> readers;
     std::shared_ptr<DuckParquetFileReader> file_reader;
     vector<unique_ptr<DataChunk>> cur_chunks;
+    idx_t cur_chunk_id = 0;
 
     template <typename ReadFinal>
     friend class ReadBase;
@@ -437,7 +438,9 @@ public:
                 if (IsNullPtr(lstate.readers[i])) {
                     continue;
                 }
-                lstate.cur_chunks[i] = std::move(GetChunk(lstate.readers[i], num_rows));
+                auto gc_result_final = GetChunk(lstate.readers[i], num_rows);
+                lstate.cur_chunks[i] = std::move(gc_result_final.first);
+                lstate.cur_chunk_id = gc_result_final.second;
                 for (idx_t j = 0; j < lstate.cur_chunks[i]->ColumnCount(); j++) {
                     output.data[gstate.global_projected_inds[i][j]].Reference(lstate.cur_chunks[i]->data[j]);
                 }
@@ -458,5 +461,9 @@ public:
     static void Register(ExtensionLoader& loader) { loader.RegisterFunction(ReadFinal::GetFunction()); }
     static TableFunction GetFunction() { return ReadFinal::GetFunction(); }
     static TableFunction GetScanFunction() { return ReadFinal::GetScanFunction(); }
+    static OperatorPartitionData GetPartitionData(ClientContext &context, TableFunctionGetPartitionInput &input) {
+        auto &lstate = input.local_state->Cast<ReadBaseLocalTableFunctionState>();
+        return OperatorPartitionData(lstate.cur_chunk_id);
+    }
 };
 }  // namespace duckdb

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -16,10 +16,10 @@
 #include <duckdb/main/extension/extension_loader.hpp>
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
-#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 
 #include <graphar/api/arrow_reader.h>
 #include <graphar/api/high_level_reader.h>
@@ -507,8 +507,10 @@ public:
 
     template <typename ValidateFunc>
     static void PushdownComplexFilterImpl(ClientContext& context, ReadBindData& read_bind_data,
-                                          vector<unique_ptr<Expression>>& filters, ValidateFunc validate_and_extract,
-                                          int64_t vertex_num) {
+                                          vector<unique_ptr<Expression>>& filters, ValidateFunc validate_and_extract) {
+        if (!read_bind_data.vid_ranges.empty()) {
+            return;
+        }
         std::set<int64_t> vids;
         vector<unique_ptr<Expression>> filters_new;
         bool already_pushed = false;
@@ -555,7 +557,8 @@ public:
             if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
                 auto& op_expr = filter->Cast<BoundFunctionExpression>();
                 const auto& fname = op_expr.function.name;
-                if (fname == "contains" || fname == "list_contains" || fname == "array_contains" || fname == "list_has" || fname == "array_has") {
+                if (fname == "contains" || fname == "list_contains" || fname == "array_contains" ||
+                    fname == "list_has" || fname == "array_has") {
                     if (op_expr.children.size() == 2 &&
                         op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
                         auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
@@ -609,23 +612,31 @@ public:
                 for (auto& child : conj.children) {
                     if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON ||
                         child->GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
-                        valid = false; break;
+                        valid = false;
+                        break;
                     }
                     auto& cmp = child->Cast<BoundComparisonExpression>();
                     std::string col;
                     Value val;
-                    if (cmp.left->GetExpressionClass()  == ExpressionClass::BOUND_COLUMN_REF &&
+                    if (cmp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
                         cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
                         col = cmp.left->ToString();
                         val = cmp.right->Cast<BoundConstantExpression>().value;
                     } else if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
-                               cmp.left->GetExpressionClass()  == ExpressionClass::BOUND_CONSTANT) {
+                               cmp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
                         col = cmp.right->ToString();
                         val = cmp.left->Cast<BoundConstantExpression>().value;
-                    } else { valid = false; break; }
+                    } else {
+                        valid = false;
+                        break;
+                    }
 
-                    if (column_name.empty()) column_name = col;
-                    else if (column_name != col) { valid = false; break; }
+                    if (column_name.empty())
+                        column_name = col;
+                    else if (column_name != col) {
+                        valid = false;
+                        break;
+                    }
                     local_vals.push_back(val);
                 }
 
@@ -648,6 +659,19 @@ public:
         }
 
         if (already_pushed) {
+            int64_t vertex_num = 0;
+            const auto& graph_info = read_bind_data.GetGraphInfo();
+            if (read_bind_data.filter_column == GID_COLUMN_INTERNAL) {
+                auto vertex_info = *std::get_if<std::shared_ptr<graphar::VertexInfo>>(&read_bind_data.type_info);
+                vertex_num = GetCountClass::GetCount(read_bind_data.type_info, graph_info->GetPrefix());
+            } else {
+                auto edge_info = *std::get_if<std::shared_ptr<graphar::EdgeInfo>>(&read_bind_data.type_info);
+                vertex_num = (read_bind_data.filter_column == SRC_GID_COLUMN)
+                                 ? GetCountClass::GetCount(graph_info->GetVertexInfo(edge_info->GetSrcType()),
+                                                           graph_info->GetPrefix())
+                                 : GetCountClass::GetCount(graph_info->GetVertexInfo(edge_info->GetDstType()),
+                                                           graph_info->GetPrefix());
+            }
             for (const auto& vid : vids) {
                 if (0 <= vid && vid < vertex_num) {
                     read_bind_data.vid_ranges.push_back({vid, vid + 1});

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -14,6 +14,12 @@
 #include <duckdb/function/table/arrow.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/main/extension/extension_loader.hpp>
+#include <duckdb/planner/expression.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 
 #include <graphar/api/arrow_reader.h>
 #include <graphar/api/high_level_reader.h>
@@ -107,8 +113,14 @@ static bool IsNullPtr(ReaderPtr& reader) {
     return std::visit([&](auto& r) { return (r == nullptr); }, reader);
 }
 
-static idx_t ReserveRowsToRead(ReaderPtr& reader) {
-    return std::visit([&](auto& r) { return r->ReserveRowsToRead(); }, reader);
+static bool CheckIfNewFileNeeded(ReaderPtr& reader) {
+    return std::visit([&](auto& r) { return r->CheckIfNewFileNeeded(); }, reader);
+}
+static void AcquirePathUnderLock(ReaderPtr& reader) {
+    std::visit([&](auto& r) { r->AcquirePathUnderLock(); }, reader);
+}
+static idx_t GetRowsNum(ReaderPtr& reader) {
+    return std::visit([&](auto& r) { return r->GetRowsNum(); }, reader);
 }
 
 static void SelectColumns(ReaderPtr& reader, std::vector<column_t> proj_columns) {
@@ -155,6 +167,7 @@ private:
 class ReadBaseGlobalTableFunctionState : public GlobalTableFunctionState {
 public:
     idx_t MaxThreads() const override { return MAX_THREADS; }
+    std::mutex lock;
 
 private:
     vector<std::string> params;
@@ -331,7 +344,7 @@ public:
         gstate.base_readers.resize(prop_types_size);
 
         auto& vid_ranges = bind_data.vid_ranges;
-        const bool has_filter = filter_column != "" && !vid_ranges.empty();
+        const bool has_filter = filter_column != "";
         const idx_t num_ranges = has_filter ? vid_ranges.size() : 1;
 
         if (gstate.column_ids.empty() ||
@@ -444,12 +457,26 @@ public:
 
         DUCKDB_GRAPHAR_LOG_DEBUG("Chunk " + std::to_string(gstate.chunk_count) + ": Begin iteration");
 
+        bool needs_new_file = false;
+        for (auto& reader : lstate.readers) {
+            if (IsNullPtr(reader)) continue;
+            if (CheckIfNewFileNeeded(reader)) {
+                needs_new_file = true;
+            }
+        }
+
+        if (needs_new_file) {
+            std::lock_guard<std::mutex> guard(gstate.lock);
+            for (auto& reader : lstate.readers) {
+                if (IsNullPtr(reader)) continue;
+                AcquirePathUnderLock(reader);
+            }
+        }
+
         idx_t num_rows = STANDARD_VECTOR_SIZE;
         for (auto& reader : lstate.readers) {
-            if (IsNullPtr(reader) || !num_rows) {
-                continue;
-            }
-            num_rows = std::min(num_rows, ReserveRowsToRead(reader));
+            if (IsNullPtr(reader)) continue;
+            num_rows = std::min(num_rows, GetRowsNum(reader));
         }
         DUCKDB_GRAPHAR_LOG_DEBUG("num rows final: " + std::to_string(num_rows));
 
@@ -476,6 +503,159 @@ public:
             t.print();
         }
         gstate.chunk_count++;
+    }
+
+    template <typename ValidateFunc>
+    static void PushdownComplexFilterImpl(ClientContext& context, ReadBindData& read_bind_data,
+                                          vector<unique_ptr<Expression>>& filters, ValidateFunc validate_and_extract,
+                                          int64_t vertex_num) {
+        std::set<int64_t> vids;
+        vector<unique_ptr<Expression>> filters_new;
+        bool already_pushed = false;
+
+        // Wrapper lambda that captures vids by reference
+        auto validate_wrapper = [&](const std::string& col, const Value& val) -> bool {
+            if (!val.IsNull()) {
+                vids.insert(val.GetValue<int64_t>());
+            }
+            return validate_and_extract(col, val);
+        };
+
+        for (auto& filter : filters) {
+            if (already_pushed) {
+                filters_new.push_back(std::move(filter));
+                continue;
+            }
+
+            bool can_pushdown = false;
+
+            // Case 0: equality comparison (col = value)
+            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+                auto& comparison = filter->Cast<BoundComparisonExpression>();
+                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
+                    bool left_is_scalar = comparison.left->IsFoldable();
+                    bool right_is_scalar = comparison.right->IsFoldable();
+                    if (left_is_scalar || right_is_scalar) {
+                        auto column_name = comparison.left->ToString();
+                        Value val;
+                        if (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+                            val = comparison.right->Cast<BoundConstantExpression>().value;
+                        } else {
+                            val = comparison.left->Cast<BoundConstantExpression>().value;
+                        }
+                        if (validate_wrapper(column_name, val)) {
+                            can_pushdown = true;
+                            read_bind_data.filter_column = column_name;
+                        }
+                    }
+                }
+            }
+
+            // Case 1: list_contains([1, 2, 3], col) -- list literal
+            if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+                auto& op_expr = filter->Cast<BoundFunctionExpression>();
+                const auto& fname = op_expr.function.name;
+                if (fname == "contains" || fname == "list_contains" || fname == "array_contains" || fname == "list_has" || fname == "array_has") {
+                    if (op_expr.children.size() == 2 &&
+                        op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                        auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
+                        auto column_name = op_expr.children[1]->ToString();
+                        auto& list_value = const_expr.value;
+
+                        if (list_value.type().id() == LogicalTypeId::LIST) {
+                            auto list_children = ListValue::GetChildren(list_value);
+                            bool any = false;
+                            for (const auto& child : list_children) {
+                                if (validate_wrapper(column_name, child)) any = true;
+                            }
+                            if (any) {
+                                read_bind_data.filter_column = column_name;
+                                can_pushdown = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Case 2: col IN (1, 2, 3) -- SQL IN operator
+            if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
+                filter->GetExpressionType() == ExpressionType::COMPARE_IN) {
+                auto& op_expr = filter->Cast<BoundOperatorExpression>();
+                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+                    auto column_name = op_expr.children[0]->ToString();
+                    bool any = false;
+                    for (idx_t i = 1; i < op_expr.children.size(); i++) {
+                        if (op_expr.children[i]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                            auto& cv = op_expr.children[i]->Cast<BoundConstantExpression>().value;
+                            if (validate_wrapper(column_name, cv)) any = true;
+                        }
+                    }
+                    if (any) {
+                        read_bind_data.filter_column = column_name;
+                        can_pushdown = true;
+                    }
+                }
+            }
+
+            // Case 3: col IN (1, 2, 3) after InClauseRewriter
+            // Small lists get rewritten to: col=1 OR col=2 OR col=3
+            if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION &&
+                filter->GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+                auto& conj = filter->Cast<BoundConjunctionExpression>();
+                std::string column_name;
+                std::vector<Value> local_vals;
+                bool valid = true;
+
+                for (auto& child : conj.children) {
+                    if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON ||
+                        child->GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+                        valid = false; break;
+                    }
+                    auto& cmp = child->Cast<BoundComparisonExpression>();
+                    std::string col;
+                    Value val;
+                    if (cmp.left->GetExpressionClass()  == ExpressionClass::BOUND_COLUMN_REF &&
+                        cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                        col = cmp.left->ToString();
+                        val = cmp.right->Cast<BoundConstantExpression>().value;
+                    } else if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+                               cmp.left->GetExpressionClass()  == ExpressionClass::BOUND_CONSTANT) {
+                        col = cmp.right->ToString();
+                        val = cmp.left->Cast<BoundConstantExpression>().value;
+                    } else { valid = false; break; }
+
+                    if (column_name.empty()) column_name = col;
+                    else if (column_name != col) { valid = false; break; }
+                    local_vals.push_back(val);
+                }
+
+                if (valid && !column_name.empty()) {
+                    bool any = false;
+                    for (auto& v : local_vals)
+                        if (validate_wrapper(column_name, v)) any = true;
+                    if (any) {
+                        read_bind_data.filter_column = column_name;
+                        can_pushdown = true;
+                    }
+                }
+            }
+
+            if (!can_pushdown) {
+                filters_new.push_back(std::move(filter));
+            } else {
+                already_pushed = true;
+            }
+        }
+
+        if (already_pushed) {
+            for (const auto& vid : vids) {
+                if (0 <= vid && vid < vertex_num) {
+                    read_bind_data.vid_ranges.push_back({vid, vid + 1});
+                }
+            }
+        }
+
+        filters = std::move(filters_new);
     }
 
     static void Register(ExtensionLoader& loader) { loader.RegisterFunction(ReadFinal::GetFunction()); }

--- a/include/functions/table/read_edges.hpp
+++ b/include/functions/table/read_edges.hpp
@@ -22,9 +22,10 @@ public:
                                          vector<LogicalType>& return_types, vector<string>& names);
 
     static BaseReaderPtr GetBaseReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                                       const std::string& filter_column);
+                                       const std::string& filter_column,
+                                       std::shared_ptr<graphar::SharedChunkCounter> counter = nullptr);
     static void SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                          const std::pair<int64_t, int64_t>& vid_range, const std::string& filter_column);
+                          const vector<std::pair<int64_t, int64_t>>& vid_ranges, const std::string& filter_column);
     static ReaderPtr GetReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate,
                                ReadBaseLocalTableFunctionState& lstate, idx_t ind, const std::string& filter_column);
 

--- a/include/functions/table/read_vertices.hpp
+++ b/include/functions/table/read_vertices.hpp
@@ -22,9 +22,10 @@ public:
                                          vector<LogicalType>& return_types, vector<string>& names);
 
     static BaseReaderPtr GetBaseReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                                       const std::string& filter_column);
+                                       const std::string& filter_column,
+                                       std::shared_ptr<graphar::SharedChunkCounter> counter = nullptr);
     static void SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                          const std::pair<int64_t, int64_t>& vid_range, const std::string& filter_column);
+                          const vector<std::pair<int64_t, int64_t>>& vid_ranges, const std::string& filter_column);
     static ReaderPtr GetReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate,
                                ReadBaseLocalTableFunctionState& lstate, idx_t ind, const std::string& filter_column);
     static unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, const FunctionData* bind_data,

--- a/include/readers/base_reader.hpp
+++ b/include/readers/base_reader.hpp
@@ -24,7 +24,10 @@ struct GetChunkResult {
     ChunkType chunk;
     std::pair<int64_t, int64_t> rows_range = {-1, -1};
     bool no_more_chunks = false;
+    duckdb::idx_t chunk_idx = -1;
 };
+
+using GetChunkFinalResult = std::pair<duckdb::unique_ptr<duckdb::DataChunk>, duckdb::idx_t>;
 
 template <typename T>
 concept IsVertexReader =
@@ -75,7 +78,7 @@ public:
             }
         }
 
-        chunk_count++;
+        cur_result.chunk_idx = chunk_count++;
         return cur_result;
     }
 

--- a/include/readers/base_reader.hpp
+++ b/include/readers/base_reader.hpp
@@ -38,12 +38,18 @@ concept IsEdgeReader =
     std::is_same_v<T, AdjListArrowChunkReader> || std::is_same_v<T, AdjListPropertyArrowChunkReader> ||
     std::is_same_v<T, AdjListChunkInfoReader> || std::is_same_v<T, AdjListPropertyChunkInfoReader>;
 
+struct SharedChunkCounter {
+    std::atomic<duckdb::idx_t> global_chunk_count{0};
+};
+
 template <typename StoredReader>
 class ThreadSafeReader {
 public:
     using ChunkType = decltype(std::declval<StoredReader>().GetChunk());
 
-    explicit ThreadSafeReader(std::shared_ptr<StoredReader> reader) : reader(std::move(reader)) {}
+    explicit ThreadSafeReader(std::shared_ptr<StoredReader> reader,
+                              std::shared_ptr<SharedChunkCounter> counter = nullptr)
+        : reader(std::move(reader)), shared_counter(counter ? counter : std::make_shared<SharedChunkCounter>()) {}
 
     template <typename... Args>
     static graphar::Result<std::shared_ptr<ThreadSafeReader>> Make(Args&&... args) {
@@ -52,13 +58,13 @@ public:
     }
 
     GetChunkResult<ChunkType> GetChunk() {
-        std::lock_guard<std::mutex> lock(mtx);
+        std::lock_guard<std::mutex> lock(chunk_mutex);
         GetChunkResult<ChunkType> cur_result;
-        if (filter_info && chunk_count == filter_info->total_chunks) {
+        if (filter_info && local_chunk_count == filter_info->total_chunks) {
             cur_result.no_more_chunks = true;
             return cur_result;
         }
-        if (chunk_count > 0) {
+        if (local_chunk_count > 0) {
             const auto next_chunk_result = reader->next_chunk();
             if (!next_chunk_result.ok() && next_chunk_result.IsIndexError()) {
                 cur_result.no_more_chunks = true;
@@ -70,15 +76,16 @@ public:
         cur_result.chunk = reader->GetChunk();
 
         if (filter_info) {
-            if (chunk_count == 0) {
+            if (local_chunk_count == 0) {
                 cur_result.rows_range.first = filter_info->offset_rows;
             }
-            if (chunk_count == filter_info->total_chunks - 1) {
+            if (local_chunk_count == filter_info->total_chunks - 1) {
                 cur_result.rows_range.second = filter_info->last_chunk_rows;
             }
         }
 
-        cur_result.chunk_idx = chunk_count++;
+        cur_result.chunk_idx = shared_counter->global_chunk_count.fetch_add(1);
+        local_chunk_count++;
         return cur_result;
     }
 
@@ -136,8 +143,9 @@ public:
 
 private:
     std::shared_ptr<StoredReader> reader;
-    std::mutex mtx;
-    duckdb::idx_t chunk_count = 0;
+    std::shared_ptr<SharedChunkCounter> shared_counter;
+    duckdb::idx_t local_chunk_count = 0;
+    std::mutex chunk_mutex;
 
     std::unique_ptr<FilterInfo> filter_info;
 };

--- a/include/readers/duck_arrow_chunk_reader.hpp
+++ b/include/readers/duck_arrow_chunk_reader.hpp
@@ -37,42 +37,61 @@ public:
         return std::make_shared<DuckArrowChunkReader>(std::move(base_ptrs), context);
     }
 
-    idx_t ReserveRowsToRead() {
-        if (!cur_chunk || read_rows == cur_chunk->size()) {
-            if (current_base_idx >= base.size()) {
-                return 0;
-            }
-            auto gc_result = base[current_base_idx]->GetChunk();
-            if (gc_result.no_more_chunks) {
-                current_base_idx++;
-                if (current_base_idx >= base.size()) {
-                    return 0;
-                }
-                gc_result = base[current_base_idx]->GetChunk();
-                if (gc_result.no_more_chunks) {
-                    return 0;
-                }
-            }
-            auto maybe_arrow_table = gc_result.chunk;
-            if (maybe_arrow_table.has_error()) {
-                DUCKDB_GRAPHAR_LOG_DEBUG("Error while getting chunk from base reader: " +
-                                         maybe_arrow_table.error().message());
-                throw maybe_arrow_table.error();
-            }
-            auto arrow_table = maybe_arrow_table.value();
-            if (!cur_chunk) {
-                cur_chunk = make_uniq<DataChunk>();
-            }
-            read_rows = 0;
-            cur_result_idx = gc_result.chunk_idx;
-            cur_read_idx = 0;
-            ConvertArrowTableToDataChunk(*arrow_table, *cur_chunk, proj_columns, context);
+    bool CheckIfNewFileNeeded() {
+        if (cur_chunk && read_rows < cur_chunk->size()) {
+            return false;
         }
-        return cur_chunk->size() - read_rows;
+        read_rows = 0;
+        return true;
+    }
+
+    void AcquirePathUnderLock() {
+        auto gc_result = base[current_base_idx]->GetChunk();
+        while (gc_result.no_more_chunks) {
+            current_base_idx++;
+            if (current_base_idx >= base.size()) {
+                next_arrow_table = nullptr;
+                path_acquired = true;
+                return;
+            }
+            gc_result = base[current_base_idx]->GetChunk();
+        }
+        
+        auto maybe_arrow_table = gc_result.chunk;
+        if (maybe_arrow_table.has_error()) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("Error while getting chunk from base reader: " +
+                                     maybe_arrow_table.error().message());
+            throw std::runtime_error(maybe_arrow_table.error().message());
+        }
+        next_arrow_table = maybe_arrow_table.value();
+        next_chunk_idx = gc_result.chunk_idx;
+        path_acquired = true;
+    }
+
+    idx_t GetRowsNum() {
+        if (path_acquired) {
+            if (next_arrow_table) {
+                if (!cur_chunk) {
+                    cur_chunk = make_uniq<DataChunk>();
+                }
+                ConvertArrowTableToDataChunk(*next_arrow_table, *cur_chunk, proj_columns, context);
+                cur_result_idx = next_chunk_idx;
+                read_rows = 0;
+                cur_read_idx = 0;
+            } else {
+                cur_chunk = nullptr;
+            }
+            path_acquired = false;
+        }
+        
+        if (cur_chunk && read_rows < cur_chunk->size()) {
+            return cur_chunk->size() - read_rows;
+        }
+        return 0;
     }
 
     graphar::Result<graphar::GetChunkFinalResult> GetChunk(idx_t num_rows) {
-        if (ReserveRowsToRead() == 0) {
+        if (GetRowsNum() == 0) {
             throw graphar::Status::IndexError("No more chunks to read!");
         }
         if (num_rows > cur_chunk->size() - read_rows) {
@@ -102,6 +121,11 @@ private:
     unique_ptr<DataChunk> cur_chunk = nullptr;
     duckdb::idx_t cur_read_idx = 0;
     duckdb::idx_t cur_result_idx = 0;
+
+    // Added for thread-safe lock separation
+    std::shared_ptr<arrow::Table> next_arrow_table = nullptr;
+    duckdb::idx_t next_chunk_idx = 0;
+    bool path_acquired = false;
 };
 
 }  // namespace duckdb

--- a/include/readers/duck_arrow_chunk_reader.hpp
+++ b/include/readers/duck_arrow_chunk_reader.hpp
@@ -56,7 +56,7 @@ public:
             }
             gc_result = base[current_base_idx]->GetChunk();
         }
-        
+
         auto maybe_arrow_table = gc_result.chunk;
         if (maybe_arrow_table.has_error()) {
             DUCKDB_GRAPHAR_LOG_DEBUG("Error while getting chunk from base reader: " +
@@ -83,7 +83,7 @@ public:
             }
             path_acquired = false;
         }
-        
+
         if (cur_chunk && read_rows < cur_chunk->size()) {
             return cur_chunk->size() - read_rows;
         }

--- a/include/readers/duck_arrow_chunk_reader.hpp
+++ b/include/readers/duck_arrow_chunk_reader.hpp
@@ -18,28 +18,40 @@ requires(std::is_same_v<BaseArrowChunkReader, graphar::TSVertexPropertyArrowChun
          std::is_same_v<BaseArrowChunkReader, graphar::TSAdjListPropertyArrowChunkReader>)
 class DuckArrowChunkReader {
 public:
-    DuckArrowChunkReader(std::shared_ptr<BaseArrowChunkReader> init_base, ClientContext& init_context)
-        : base(std::move(init_base)), context(init_context) {}
+    DuckArrowChunkReader(std::vector<std::shared_ptr<BaseArrowChunkReader>> init_bases, ClientContext& init_context)
+        : base(std::move(init_bases)), context(init_context) {}
 
-    static graphar::Result<std::shared_ptr<DuckArrowChunkReader>> Make(ClientContext& context,
-                                                                       std::shared_ptr<BaseArrowChunkReader> base_ptr) {
-        if (!base_ptr) {
-            return graphar::Status::Invalid("base_ptr can't be null!");
+    static graphar::Result<std::shared_ptr<DuckArrowChunkReader>> Make(
+        ClientContext& context, std::vector<std::shared_ptr<BaseArrowChunkReader>> base_ptrs) {
+        if (base_ptrs.empty()) {
+            return graphar::Status::Invalid("base_ptrs can't be empty!");
         }
-        return std::make_shared<DuckArrowChunkReader>(std::move(base_ptr), context);
+        return std::make_shared<DuckArrowChunkReader>(std::move(base_ptrs), context);
     }
 
     template <typename... Args>
     static graphar::Result<std::shared_ptr<DuckArrowChunkReader>> Make(ClientContext& context, Args&&... args) {
         GAR_ASSIGN_OR_RAISE(auto base_ptr, BaseArrowChunkReader::Make(std::forward<Args>(args)...));
-        return std::make_shared<DuckArrowChunkReader>(std::move(base_ptr), context);
+        std::vector<std::shared_ptr<BaseArrowChunkReader>> base_ptrs;
+        base_ptrs.push_back(std::move(base_ptr));
+        return std::make_shared<DuckArrowChunkReader>(std::move(base_ptrs), context);
     }
 
     idx_t ReserveRowsToRead() {
         if (!cur_chunk || read_rows == cur_chunk->size()) {
-            auto gc_result = base->GetChunk();
-            if (gc_result.no_more_chunks) {
+            if (current_base_idx >= base.size()) {
                 return 0;
+            }
+            auto gc_result = base[current_base_idx]->GetChunk();
+            if (gc_result.no_more_chunks) {
+                current_base_idx++;
+                if (current_base_idx >= base.size()) {
+                    return 0;
+                }
+                gc_result = base[current_base_idx]->GetChunk();
+                if (gc_result.no_more_chunks) {
+                    return 0;
+                }
             }
             auto maybe_arrow_table = gc_result.chunk;
             if (maybe_arrow_table.has_error()) {
@@ -84,7 +96,8 @@ public:
 private:
     std::vector<column_t> proj_columns;
     ClientContext& context;
-    std::shared_ptr<BaseArrowChunkReader> base;
+    std::vector<std::shared_ptr<BaseArrowChunkReader>> base;
+    size_t current_base_idx = 0;
     idx_t read_rows = 0;
     unique_ptr<DataChunk> cur_chunk = nullptr;
     duckdb::idx_t cur_read_idx = 0;

--- a/include/readers/duck_arrow_chunk_reader.hpp
+++ b/include/readers/duck_arrow_chunk_reader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "readers/base_reader.hpp"
 #include "utils/func.hpp"
 #include "utils/global_log_manager.hpp"
 
@@ -51,12 +52,14 @@ public:
                 cur_chunk = make_uniq<DataChunk>();
             }
             read_rows = 0;
+            cur_result_idx = gc_result.chunk_idx;
+            cur_read_idx = 0;
             ConvertArrowTableToDataChunk(*arrow_table, *cur_chunk, proj_columns, context);
         }
         return cur_chunk->size() - read_rows;
     }
 
-    graphar::Result<unique_ptr<DataChunk>> GetChunk(idx_t num_rows) {
+    graphar::Result<graphar::GetChunkFinalResult> GetChunk(idx_t num_rows) {
         if (ReserveRowsToRead() == 0) {
             throw graphar::Status::IndexError("No more chunks to read!");
         }
@@ -68,7 +71,8 @@ public:
         res->Reference(*cur_chunk);
         res->Slice(read_rows, num_rows);
         read_rows += num_rows;
-        return res;
+        cur_read_idx++;
+        return std::make_pair(std::move(res), GetChunkIdx(cur_result_idx, cur_read_idx));
     }
 
     void FilterByRange(std::pair<int64_t, int64_t> vid_range, const std::string& filter_column) {
@@ -83,6 +87,8 @@ private:
     std::shared_ptr<BaseArrowChunkReader> base;
     idx_t read_rows = 0;
     unique_ptr<DataChunk> cur_chunk = nullptr;
+    duckdb::idx_t cur_read_idx = 0;
+    duckdb::idx_t cur_result_idx = 0;
 };
 
 }  // namespace duckdb

--- a/include/readers/duck_chunk_reader.hpp
+++ b/include/readers/duck_chunk_reader.hpp
@@ -11,7 +11,6 @@
 #include <graphar/types.h>
 
 #include <duckdb.hpp>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -53,9 +52,13 @@ private:
 template <typename BaseArrowChunkReader>
 class BaseDuckChunkReader {
 public:
-    BaseDuckChunkReader(ClientContext& init_context, std::shared_ptr<BaseArrowChunkReader> init_base,
+    BaseDuckChunkReader(ClientContext& init_context, std::vector<std::shared_ptr<BaseArrowChunkReader>> init_bases,
                         std::shared_ptr<DuckParquetFileReader> init_file_reader)
-        : context(init_context), base(std::move(init_base)), file_reader(std::move(init_file_reader)) {}
+        : context(init_context), bases(std::move(init_bases)), file_reader(std::move(init_file_reader)) {
+        if (bases.empty()) {
+            throw std::runtime_error("Bases vector cannot be empty");
+        }
+    }
 
     idx_t ReserveRowsToRead() {
         if (cur_chunk && read_rows < cur_chunk->size()) {
@@ -65,9 +68,13 @@ public:
         if (cur_result && (cur_chunk = cur_result->Fetch())) {
             return cur_chunk->size();
         }
-        auto gc_result = base->GetChunk();
-        if (gc_result.no_more_chunks) {
-            return 0;
+        auto gc_result = bases[base_idx]->GetChunk();
+        while (gc_result.no_more_chunks) {
+            base_idx++;
+            if (base_idx >= bases.size()) {
+                return 0;
+            }
+            gc_result = bases[base_idx]->GetChunk();
         }
         auto maybe_path = gc_result.chunk;
         if (maybe_path.has_error()) {
@@ -106,7 +113,8 @@ public:
     }
 
 protected:
-    std::shared_ptr<BaseArrowChunkReader> base;
+    std::vector<std::shared_ptr<BaseArrowChunkReader>> bases;
+    duckdb::idx_t base_idx = 0;
     std::vector<duckdb::column_t> proj_columns;
     duckdb::idx_t read_rows = 0;
     duckdb::unique_ptr<duckdb::DataChunk> cur_chunk = nullptr;
@@ -129,12 +137,16 @@ public:
         ClientContext& context, std::shared_ptr<DuckParquetFileReader> file_reader,
         const std::shared_ptr<graphar::VertexInfo>& vertex_info,
         const std::shared_ptr<graphar::PropertyGroup>& property_group, const std::string& prefix,
-        std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader> init_baseptr = nullptr) {
-        if (!init_baseptr) {
-            GAR_ASSIGN_OR_RAISE(init_baseptr,
+        const std::vector<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>>& init_baseptrs = {}) {
+        std::vector<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>> bases;
+        if (init_baseptrs.empty()) {
+            GAR_ASSIGN_OR_RAISE(auto init_baseptr,
                                 graphar::TSVertexPropertyChunkInfoReader::Make(vertex_info, property_group, prefix));
+            bases.push_back(std::move(init_baseptr));
+        } else {
+            bases = init_baseptrs;
         }
-        return std::make_shared<DuckVertexChunkReader>(vertex_info, context, std::move(init_baseptr), file_reader);
+        return std::make_shared<DuckVertexChunkReader>(vertex_info, context, std::move(bases), file_reader);
     }
 
 private:
@@ -144,11 +156,11 @@ private:
 template <typename BaseArrowChunkReader>
 class DuckEdgeChunkReader : public BaseDuckChunkReader<BaseArrowChunkReader> {
 public:
-    DuckEdgeChunkReader(std::shared_ptr<BaseArrowChunkReader> init_base,
+    DuckEdgeChunkReader(const std::vector<std::shared_ptr<BaseArrowChunkReader>>& init_bases,
                         std::shared_ptr<DuckParquetFileReader> init_file_reader, ClientContext& init_context,
                         const std::shared_ptr<graphar::EdgeInfo>& edge_info_, graphar::AdjListType adj_list_type_,
                         const std::string& prefix_)
-        : BaseDuckChunkReader<BaseArrowChunkReader>(init_context, std::move(init_base), std::move(init_file_reader)),
+        : BaseDuckChunkReader<BaseArrowChunkReader>(init_context, std::move(init_bases), std::move(init_file_reader)),
           edge_info(edge_info_),
           adj_list_type(adj_list_type_),
           prefix(prefix_) {}
@@ -156,25 +168,31 @@ public:
     static graphar::Result<std::shared_ptr<DuckEdgeChunkReader>> Make(
         ClientContext& context, std::shared_ptr<DuckParquetFileReader> file_reader,
         const std::shared_ptr<graphar::EdgeInfo>& edge_info, graphar::AdjListType adj_list_type,
-        const std::string& prefix, std::shared_ptr<BaseArrowChunkReader> init_baseptr = nullptr) {
-        if (!init_baseptr) {
-            GAR_ASSIGN_OR_RAISE(init_baseptr, BaseArrowChunkReader::Make(edge_info, adj_list_type, prefix));
+        const std::string& prefix, const std::vector<std::shared_ptr<BaseArrowChunkReader>>& init_baseptrs = {}) {
+        std::vector<std::shared_ptr<BaseArrowChunkReader>> bases;
+        if (init_baseptrs.empty()) {
+            GAR_ASSIGN_OR_RAISE(auto init_baseptr, BaseArrowChunkReader::Make(edge_info, adj_list_type, prefix));
+            bases.push_back(std::move(init_baseptr));
+        } else {
+            bases = init_baseptrs;
         }
-        return std::make_shared<DuckEdgeChunkReader>(std::move(init_baseptr), file_reader, context, edge_info,
-                                                     adj_list_type, prefix);
+        return std::make_shared<DuckEdgeChunkReader>(bases, file_reader, context, edge_info, adj_list_type, prefix);
     }
 
     static graphar::Result<std::shared_ptr<DuckEdgeChunkReader>> Make(
         ClientContext& context, std::shared_ptr<DuckParquetFileReader> file_reader,
         const std::shared_ptr<graphar::EdgeInfo>& edge_info,
         const std::shared_ptr<graphar::PropertyGroup>& property_group, graphar::AdjListType adj_list_type,
-        const std::string& prefix, std::shared_ptr<BaseArrowChunkReader> init_baseptr = nullptr) {
-        if (!init_baseptr) {
-            GAR_ASSIGN_OR_RAISE(init_baseptr,
+        const std::string& prefix, const std::vector<std::shared_ptr<BaseArrowChunkReader>>& init_baseptrs = {}) {
+        std::vector<std::shared_ptr<BaseArrowChunkReader>> bases;
+        if (init_baseptrs.empty()) {
+            GAR_ASSIGN_OR_RAISE(auto init_baseptr,
                                 BaseArrowChunkReader::Make(edge_info, property_group, adj_list_type, prefix))
+            bases.push_back(std::move(init_baseptr));
+        } else {
+            bases = init_baseptrs;
         }
-        return std::make_shared<DuckEdgeChunkReader>(std::move(init_baseptr), file_reader, context, edge_info,
-                                                     adj_list_type, prefix);
+        return std::make_shared<DuckEdgeChunkReader>(bases, file_reader, context, edge_info, adj_list_type, prefix);
     }
 
     void SelectColumns(std::vector<duckdb::column_t> proj_columns_) {

--- a/include/readers/duck_chunk_reader.hpp
+++ b/include/readers/duck_chunk_reader.hpp
@@ -55,41 +55,68 @@ public:
     BaseDuckChunkReader(ClientContext& init_context, std::vector<std::shared_ptr<BaseArrowChunkReader>> init_bases,
                         std::shared_ptr<DuckParquetFileReader> init_file_reader)
         : context(init_context), bases(std::move(init_bases)), file_reader(std::move(init_file_reader)) {
-        if (bases.empty()) {
-            throw std::runtime_error("Bases vector cannot be empty");
-        }
     }
 
-    idx_t ReserveRowsToRead() {
+    bool CheckIfNewFileNeeded() {
         if (cur_chunk && read_rows < cur_chunk->size()) {
-            return cur_chunk->size() - read_rows;
+            return false;
         }
         read_rows = 0;
-        if (cur_result && (cur_chunk = cur_result->Fetch())) {
-            return cur_chunk->size();
+        if (cur_result) {
+            cur_chunk = cur_result->Fetch();
+            if (cur_chunk && cur_chunk->size() > 0) {
+                return false;
+            }
+            cur_result = nullptr;
+        }
+        return true;
+    }
+
+    void AcquirePathUnderLock() {
+        next_path = "";
+        path_acquired = true;
+        if (base_idx >= bases.size()) {
+            return;
         }
         auto gc_result = bases[base_idx]->GetChunk();
         while (gc_result.no_more_chunks) {
             base_idx++;
             if (base_idx >= bases.size()) {
-                return 0;
+                return;
             }
             gc_result = bases[base_idx]->GetChunk();
         }
         auto maybe_path = gc_result.chunk;
         if (maybe_path.has_error()) {
-            throw maybe_path.error();
+            throw std::runtime_error(maybe_path.error().message());
         }
-        auto path = maybe_path.value();
-        cur_result_idx = gc_result.chunk_idx;
-        cur_read_idx = 0;
-        cur_result = file_reader->ReadFileToTable(path, proj_columns, gc_result.rows_range);
-        cur_chunk = cur_result->Fetch();
-        return cur_chunk->size();
+        next_path = maybe_path.value();
+        next_rows_range = gc_result.rows_range;
+        next_chunk_idx = gc_result.chunk_idx;
+        path_acquired = true;
+    }
+
+    idx_t GetRowsNum() {
+        if (path_acquired) {
+            if (!next_path.empty()) {
+                cur_result = file_reader->ReadFileToTable(next_path, proj_columns, next_rows_range);
+                cur_chunk = cur_result->Fetch();
+                cur_result_idx = next_chunk_idx;
+            } else {
+                cur_chunk = nullptr;
+            }
+            path_acquired = false;
+            read_rows = 0;
+            cur_read_idx = 0;
+        }
+        if (cur_chunk && read_rows < cur_chunk->size()) {
+            return cur_chunk->size() - read_rows;
+        }
+        return 0;
     }
 
     graphar::Result<graphar::GetChunkFinalResult> GetChunk(duckdb::idx_t num_rows) {
-        if (ReserveRowsToRead() == 0) {
+        if (GetRowsNum() == 0) {
             throw graphar::Status::IndexError("No more chunks to read!");
         }
         if (num_rows > cur_chunk->size() - read_rows) {
@@ -121,9 +148,12 @@ protected:
     duckdb::idx_t cur_read_idx = 0;
     duckdb::unique_ptr<duckdb::QueryResult> cur_result = nullptr;
     duckdb::idx_t cur_result_idx = 0;
-
     std::shared_ptr<DuckParquetFileReader> file_reader;
     ClientContext& context;
+    std::string next_path = "";
+    std::pair<int64_t, int64_t> next_rows_range = {-1, -1};
+    duckdb::idx_t next_chunk_idx = 0;
+    bool path_acquired = false;
 };
 
 class DuckVertexChunkReader : public BaseDuckChunkReader<graphar::TSVertexPropertyChunkInfoReader> {
@@ -139,13 +169,7 @@ public:
         const std::shared_ptr<graphar::PropertyGroup>& property_group, const std::string& prefix,
         const std::vector<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>>& init_baseptrs = {}) {
         std::vector<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>> bases;
-        if (init_baseptrs.empty()) {
-            GAR_ASSIGN_OR_RAISE(auto init_baseptr,
-                                graphar::TSVertexPropertyChunkInfoReader::Make(vertex_info, property_group, prefix));
-            bases.push_back(std::move(init_baseptr));
-        } else {
-            bases = init_baseptrs;
-        }
+        bases = init_baseptrs;
         return std::make_shared<DuckVertexChunkReader>(vertex_info, context, std::move(bases), file_reader);
     }
 
@@ -170,12 +194,7 @@ public:
         const std::shared_ptr<graphar::EdgeInfo>& edge_info, graphar::AdjListType adj_list_type,
         const std::string& prefix, const std::vector<std::shared_ptr<BaseArrowChunkReader>>& init_baseptrs = {}) {
         std::vector<std::shared_ptr<BaseArrowChunkReader>> bases;
-        if (init_baseptrs.empty()) {
-            GAR_ASSIGN_OR_RAISE(auto init_baseptr, BaseArrowChunkReader::Make(edge_info, adj_list_type, prefix));
-            bases.push_back(std::move(init_baseptr));
-        } else {
-            bases = init_baseptrs;
-        }
+        bases = init_baseptrs;
         return std::make_shared<DuckEdgeChunkReader>(bases, file_reader, context, edge_info, adj_list_type, prefix);
     }
 

--- a/include/readers/duck_chunk_reader.hpp
+++ b/include/readers/duck_chunk_reader.hpp
@@ -54,8 +54,7 @@ class BaseDuckChunkReader {
 public:
     BaseDuckChunkReader(ClientContext& init_context, std::vector<std::shared_ptr<BaseArrowChunkReader>> init_bases,
                         std::shared_ptr<DuckParquetFileReader> init_file_reader)
-        : context(init_context), bases(std::move(init_bases)), file_reader(std::move(init_file_reader)) {
-    }
+        : context(init_context), bases(std::move(init_bases)), file_reader(std::move(init_file_reader)) {}
 
     bool CheckIfNewFileNeeded() {
         if (cur_chunk && read_rows < cur_chunk->size()) {

--- a/include/readers/duck_chunk_reader.hpp
+++ b/include/readers/duck_chunk_reader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "readers/base_reader.hpp"
+#include "utils/func.hpp"
 
 #include <graphar/chunk_info_reader.h>
 #include <graphar/fwd.h>
@@ -73,12 +74,14 @@ public:
             throw maybe_path.error();
         }
         auto path = maybe_path.value();
+        cur_result_idx = gc_result.chunk_idx;
+        cur_read_idx = 0;
         cur_result = file_reader->ReadFileToTable(path, proj_columns, gc_result.rows_range);
         cur_chunk = cur_result->Fetch();
         return cur_chunk->size();
     }
 
-    graphar::Result<duckdb::unique_ptr<duckdb::DataChunk>> GetChunk(duckdb::idx_t num_rows) {
+    graphar::Result<graphar::GetChunkFinalResult> GetChunk(duckdb::idx_t num_rows) {
         if (ReserveRowsToRead() == 0) {
             throw graphar::Status::IndexError("No more chunks to read!");
         }
@@ -91,7 +94,8 @@ public:
         res->Reference(*cur_chunk);
         res->Slice(read_rows, num_rows);
         read_rows += num_rows;
-        return res;
+        cur_read_idx++;
+        return std::make_pair(std::move(res), GetChunkIdx(cur_result_idx, cur_read_idx));
     }
 
     void SelectColumns(std::vector<duckdb::column_t> proj_columns_) {
@@ -106,7 +110,9 @@ protected:
     std::vector<duckdb::column_t> proj_columns;
     duckdb::idx_t read_rows = 0;
     duckdb::unique_ptr<duckdb::DataChunk> cur_chunk = nullptr;
+    duckdb::idx_t cur_read_idx = 0;
     duckdb::unique_ptr<duckdb::QueryResult> cur_result = nullptr;
+    duckdb::idx_t cur_result_idx = 0;
 
     std::shared_ptr<DuckParquetFileReader> file_reader;
     ClientContext& context;

--- a/include/utils/func.hpp
+++ b/include/utils/func.hpp
@@ -138,4 +138,12 @@ public:
     }
 };
 
+static idx_t GetChunkIdx(duckdb::idx_t result_idx, duckdb::idx_t read_idx) {
+     if (result_idx > NumericLimits<uint32_t>::Maximum() || read_idx > NumericLimits<uint32_t>::Maximum()) {
+        throw OutOfRangeException("Overflow encountered in GetChunkIdx with result_idx = %llu and read_idx = %llu",
+                                 result_idx, read_idx);
+    }
+    return (result_idx) << 32 | read_idx;
+}
+
 }  // namespace duckdb

--- a/include/utils/func.hpp
+++ b/include/utils/func.hpp
@@ -139,9 +139,9 @@ public:
 };
 
 static idx_t GetChunkIdx(duckdb::idx_t result_idx, duckdb::idx_t read_idx) {
-     if (result_idx > NumericLimits<uint32_t>::Maximum() || read_idx > NumericLimits<uint32_t>::Maximum()) {
+    if (result_idx > NumericLimits<uint32_t>::Maximum() || read_idx > NumericLimits<uint32_t>::Maximum()) {
         throw OutOfRangeException("Overflow encountered in GetChunkIdx with result_idx = %llu and read_idx = %llu",
-                                 result_idx, read_idx);
+                                  result_idx, read_idx);
     }
     return (result_idx) << 32 | read_idx;
 }

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -9,14 +9,15 @@
 #include <duckdb/function/table/arrow.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
 
 #include <graphar/api/arrow_reader.h>
 #include <graphar/api/high_level_reader.h>
 #include <graphar/arrow/chunk_reader.h>
 #include <graphar/expression.h>
 #include <graphar/fwd.h>
-
-#include <iostream>
 
 namespace duckdb {
 //-------------------------------------------------------------------
@@ -78,7 +79,8 @@ unique_ptr<FunctionData> ReadEdges::Bind(ClientContext& context, TableFunctionBi
 // GetBaseReader
 //-------------------------------------------------------------------
 BaseReaderPtr ReadEdges::GetBaseReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                                       const std::string& filter_column) {
+                                       const std::string& filter_column,
+                                       std::shared_ptr<graphar::SharedChunkCounter> counter) {
     DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader");
     graphar::AdjListType adj_list_type;
     if (filter_column == "" or filter_column == SRC_GID_COLUMN) {
@@ -97,28 +99,30 @@ BaseReaderPtr ReadEdges::GetBaseReader(ClientContext& context, ReadBaseGlobalTab
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making src and dst reader...");
         if (edge_info->GetAdjacentList(adj_list_type)->GetFileType() == graphar::FileType::PARQUET) {
             DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making duckdb reader...");
-            return ConvertBaseReader(graphar::AdjListChunkInfoReader::Make(edge_info, adj_list_type, prefix));
+            return ConvertBaseReader(graphar::AdjListChunkInfoReader::Make(edge_info, adj_list_type, prefix), counter);
         } else {
             DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making arrow reader...");
-            return ConvertBaseReader(graphar::AdjListArrowChunkReader::Make(edge_info, adj_list_type, prefix));
+            return ConvertBaseReader(graphar::AdjListArrowChunkReader::Make(edge_info, adj_list_type, prefix), counter);
         }
     }
     DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making property reader...");
     if (edge_info->GetAdjacentList(adj_list_type)->GetFileType() == graphar::FileType::PARQUET) {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making duckdb reader...");
         return ConvertBaseReader(
-            graphar::AdjListPropertyChunkInfoReader::Make(edge_info, gstate.pgs[ind - 1], adj_list_type, prefix));
+            graphar::AdjListPropertyChunkInfoReader::Make(edge_info, gstate.pgs[ind - 1], adj_list_type, prefix),
+            counter);
     } else {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetBaseReader: making arrow reader...");
         return ConvertBaseReader(
-            graphar::AdjListPropertyArrowChunkReader::Make(edge_info, gstate.pgs[ind - 1], adj_list_type, prefix));
+            graphar::AdjListPropertyArrowChunkReader::Make(edge_info, gstate.pgs[ind - 1], adj_list_type, prefix),
+            counter);
     }
 }
 //-------------------------------------------------------------------
 // SetFilter
 //-------------------------------------------------------------------
 void ReadEdges::SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                          const std::pair<int64_t, int64_t>& vid_range, const std::string& filter_column) {
+                          const vector<std::pair<int64_t, int64_t>>& vid_ranges, const std::string& filter_column) {
     DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::SetFilter");
     auto edge_info = *std::get_if<std::shared_ptr<graphar::EdgeInfo>>(&gstate.type_info);
     if (!edge_info) {
@@ -129,12 +133,15 @@ void ReadEdges::SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionSta
                                                              gstate.graph_info->GetPrefix())
                                    : GetCountClass::GetCount(gstate.graph_info->GetVertexInfo(edge_info->GetDstType()),
                                                              gstate.graph_info->GetPrefix());
-    if (vid_range.first < 0 || vid_range.first >= vertex_num || vid_range.second <= 0 ||
-        vid_range.second > vertex_num) {
-        throw BinderException("Invalid filter vertex id range");
-    }
     const auto& prefix = gstate.graph_info->GetPrefix();
-    FilterByRangeEdge(gstate.base_readers[ind], vid_range, filter_column, edge_info, prefix);
+    for (idx_t r = 0; r < vid_ranges.size(); ++r) {
+        const auto& vid_range = vid_ranges[r];
+        if (vid_range.first < 0 || vid_range.first >= vertex_num || vid_range.second <= 0 ||
+            vid_range.second > vertex_num) {
+            throw BinderException("Invalid filter vertex id range");
+        }
+        FilterByRangeEdge(gstate.base_readers[ind][r], vid_range, filter_column, edge_info, prefix);
+    }
 }
 //-------------------------------------------------------------------
 // GetReader
@@ -159,27 +166,41 @@ ReaderPtr ReadEdges::GetReader(ClientContext& context, ReadBaseGlobalTableFuncti
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making src and dst reader...");
         if (edge_info->GetAdjacentList(adj_list_type)->GetFileType() == graphar::FileType::PARQUET) {
             DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making duckdb reader...");
-            auto base_reader = std::get<std::shared_ptr<graphar::TSAdjListChunkInfoReader>>(gstate.base_readers[ind]);
+            std::vector<std::shared_ptr<graphar::TSAdjListChunkInfoReader>> base_readers;
+            base_readers.reserve(gstate.base_readers[ind].size());
+            for (const auto& base_reader : gstate.base_readers[ind]) {
+                base_readers.push_back(std::get<std::shared_ptr<graphar::TSAdjListChunkInfoReader>>(base_reader));
+            }
             return ConvertReader(graphar::DuckAdjListChunkReader::Make(context, lstate.file_reader, edge_info,
-                                                                       adj_list_type, prefix, base_reader));
+                                                                       adj_list_type, prefix, base_readers));
         } else {
             DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making arrow reader...");
-            auto base_reader = std::get<std::shared_ptr<graphar::TSAdjListArrowChunkReader>>(gstate.base_readers[ind]);
-            return ConvertReader(graphar::DuckAdjListArrowChunkReader::Make(context, base_reader));
+            std::vector<std::shared_ptr<graphar::TSAdjListArrowChunkReader>> base_readers;
+            base_readers.reserve(gstate.base_readers[ind].size());
+            for (const auto& base_reader : gstate.base_readers[ind]) {
+                base_readers.push_back(std::get<std::shared_ptr<graphar::TSAdjListArrowChunkReader>>(base_reader));
+            }
+            return ConvertReader(graphar::DuckAdjListArrowChunkReader::Make(context, base_readers));
         }
     }
     DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making property reader...");
     if (edge_info->GetAdjacentList(adj_list_type)->GetFileType() == graphar::FileType::PARQUET) {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making duckdb reader...");
-        auto base_reader =
-            std::get<std::shared_ptr<graphar::TSAdjListPropertyChunkInfoReader>>(gstate.base_readers[ind]);
+        std::vector<std::shared_ptr<graphar::TSAdjListPropertyChunkInfoReader>> base_readers;
+        base_readers.reserve(gstate.base_readers[ind].size());
+        for (const auto& base_reader : gstate.base_readers[ind]) {
+            base_readers.push_back(std::get<std::shared_ptr<graphar::TSAdjListPropertyChunkInfoReader>>(base_reader));
+        }
         return ConvertReader(graphar::DuckAdjListPropertyChunkReader::Make(
-            context, lstate.file_reader, edge_info, gstate.pgs[ind - 1], adj_list_type, prefix, base_reader));
+            context, lstate.file_reader, edge_info, gstate.pgs[ind - 1], adj_list_type, prefix, base_readers));
     } else {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetReader: making arrow reader...");
-        auto base_reader =
-            std::get<std::shared_ptr<graphar::TSAdjListPropertyArrowChunkReader>>(gstate.base_readers[ind]);
-        return ConvertReader(graphar::DuckAdjListPropertyArrowChunkReader::Make(context, base_reader));
+        std::vector<std::shared_ptr<graphar::TSAdjListPropertyArrowChunkReader>> base_readers;
+        base_readers.reserve(gstate.base_readers[ind].size());
+        for (const auto& base_reader : gstate.base_readers[ind]) {
+            base_readers.push_back(std::get<std::shared_ptr<graphar::TSAdjListPropertyArrowChunkReader>>(base_reader));
+        }
+        return ConvertReader(graphar::DuckAdjListPropertyArrowChunkReader::Make(context, base_readers));
     }
 }
 //-------------------------------------------------------------------
@@ -209,7 +230,6 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
     auto read_bind_data = dynamic_cast<ReadBindData*>(bind_data);
     for (auto& pg : read_bind_data->pgs) {
         if (pg->GetFileType() != graphar::FileType::PARQUET) {
-            // our pushdown works greatly only for parquet files
             return;
         }
     }
@@ -239,8 +259,46 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
                                 graphar::FileType::PARQUET) {
                         can_pushdown = true;
                         const auto vid = std::stoll(comparison.right->ToString());
-                        read_bind_data->vid_range = std::make_pair(vid, vid + 1);
+                        read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
                         read_bind_data->filter_column = column_name;
+                    }
+                }
+            }
+        }
+        if (filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+            auto& op_expr = filter->Cast<BoundFunctionExpression>();
+            if (op_expr.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+                if (op_expr.children.size() != 2) {
+                    continue;
+                }
+                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                    auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
+                    auto column_name = op_expr.children[1]->ToString();
+                    if (column_name == SRC_GID_COLUMN &&
+                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_source) &&
+                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType() ==
+                                graphar::FileType::PARQUET ||
+                        column_name == DST_GID_COLUMN &&
+                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_dest) &&
+                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType() ==
+                                graphar::FileType::PARQUET) {
+                        std::vector<int64_t> vids;
+                        auto& list_value = const_expr.value;
+                        if (list_value.type().id() == LogicalTypeId::LIST) {
+                            auto children = ListValue::GetChildren(list_value);
+                            for (const auto& child : children) {
+                                if (!child.IsNull()) {
+                                    vids.push_back(child.GetValue<int64_t>());
+                                }
+                            }
+                        }
+                        if (!vids.empty()) {
+                            can_pushdown = true;
+                            for (const auto vid : vids) {
+                                read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
+                            }
+                            read_bind_data->filter_column = column_name;
+                        }
                     }
                 }
             }

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -3,6 +3,8 @@
 #include "utils/benchmark.hpp"
 #include "utils/func.hpp"
 
+#include <set>
+
 #include <arrow/c/bridge.h>
 
 #include <duckdb/common/named_parameter_map.hpp>
@@ -233,83 +235,25 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
             return;
         }
     }
+    
     auto edge_info = *std::get_if<std::shared_ptr<graphar::EdgeInfo>>(&read_bind_data->type_info);
-    vector<unique_ptr<Expression>> filters_new;
-    bool already_pushed = false;
-    for (auto& filter : filters) {
-        if (already_pushed) {
-            filters_new.push_back(std::move(filter));
-            continue;
-        }
-        bool can_pushdown = false;
-        if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-            auto& comparison = filter->Cast<BoundComparisonExpression>();
-            if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
-                bool left_is_scalar = comparison.left->IsFoldable();
-                bool right_is_scalar = comparison.right->IsFoldable();
-                if (left_is_scalar || right_is_scalar) {
-                    auto column_name = comparison.left->ToString();
-                    if (column_name == SRC_GID_COLUMN &&
-                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_source) &&
-                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType() ==
-                                graphar::FileType::PARQUET ||
-                        column_name == DST_GID_COLUMN &&
-                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_dest) &&
-                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType() ==
-                                graphar::FileType::PARQUET) {
-                        can_pushdown = true;
-                        const auto vid = std::stoll(comparison.right->ToString());
-                        read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
-                        read_bind_data->filter_column = column_name;
-                    }
-                }
-            }
-        }
-        if (filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-            auto& op_expr = filter->Cast<BoundFunctionExpression>();
-            if (op_expr.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
-                if (op_expr.children.size() != 2) {
-                    continue;
-                }
-                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                    auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
-                    auto column_name = op_expr.children[1]->ToString();
-                    if (column_name == SRC_GID_COLUMN &&
-                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_source) &&
-                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType() ==
-                                graphar::FileType::PARQUET ||
-                        column_name == DST_GID_COLUMN &&
-                            edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_dest) &&
-                            edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType() ==
-                                graphar::FileType::PARQUET) {
-                        std::vector<int64_t> vids;
-                        auto& list_value = const_expr.value;
-                        if (list_value.type().id() == LogicalTypeId::LIST) {
-                            auto children = ListValue::GetChildren(list_value);
-                            for (const auto& child : children) {
-                                if (!child.IsNull()) {
-                                    vids.push_back(child.GetValue<int64_t>());
-                                }
-                            }
-                        }
-                        if (!vids.empty()) {
-                            can_pushdown = true;
-                            for (const auto vid : vids) {
-                                read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
-                            }
-                            read_bind_data->filter_column = column_name;
-                        }
-                    }
-                }
-            }
-        }
-        if (!can_pushdown) {
-            filters_new.push_back(std::move(filter));
-        } else {
-            already_pushed = true;
-        }
-    }
-    filters = std::move(filters_new);
+    const auto vertex_num = GetCountClass::GetCount(read_bind_data->type_info, read_bind_data->GetGraphInfo()->GetPrefix());
+    
+    // Validation lambda for edges
+    auto validate = [&](const std::string& col, const Value& val) -> bool {
+        if (col != SRC_GID_COLUMN && col != DST_GID_COLUMN) return false;
+        if (col == SRC_GID_COLUMN &&
+            (!edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_source) ||
+             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType()
+                 != graphar::FileType::PARQUET)) return false;
+        if (col == DST_GID_COLUMN &&
+            (!edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_dest) ||
+             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType()
+                 != graphar::FileType::PARQUET)) return false;
+        return true;
+    };
+    
+    ReadBase<ReadEdges>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate, vertex_num);
 }
 //-------------------------------------------------------------------
 // InitFunction

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -238,7 +238,6 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
 
     auto edge_info = *std::get_if<std::shared_ptr<graphar::EdgeInfo>>(&read_bind_data->type_info);
 
-    // Validation lambda for edges
     auto validate = [&](const std::string& col, const Value& val) -> bool {
         if (col != SRC_GID_COLUMN && col != DST_GID_COLUMN) return false;
         if (col == SRC_GID_COLUMN &&

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -3,8 +3,6 @@
 #include "utils/benchmark.hpp"
 #include "utils/func.hpp"
 
-#include <set>
-
 #include <arrow/c/bridge.h>
 
 #include <duckdb/common/named_parameter_map.hpp>
@@ -20,6 +18,8 @@
 #include <graphar/arrow/chunk_reader.h>
 #include <graphar/expression.h>
 #include <graphar/fwd.h>
+
+#include <set>
 
 namespace duckdb {
 //-------------------------------------------------------------------
@@ -235,25 +235,26 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
             return;
         }
     }
-    
+
     auto edge_info = *std::get_if<std::shared_ptr<graphar::EdgeInfo>>(&read_bind_data->type_info);
-    const auto vertex_num = GetCountClass::GetCount(read_bind_data->type_info, read_bind_data->GetGraphInfo()->GetPrefix());
-    
+
     // Validation lambda for edges
     auto validate = [&](const std::string& col, const Value& val) -> bool {
         if (col != SRC_GID_COLUMN && col != DST_GID_COLUMN) return false;
         if (col == SRC_GID_COLUMN &&
             (!edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_source) ||
-             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType()
-                 != graphar::FileType::PARQUET)) return false;
+             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_source)->GetFileType() !=
+                 graphar::FileType::PARQUET))
+            return false;
         if (col == DST_GID_COLUMN &&
             (!edge_info->HasAdjacentListType(graphar::AdjListType::ordered_by_dest) ||
-             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType()
-                 != graphar::FileType::PARQUET)) return false;
+             edge_info->GetAdjacentList(graphar::AdjListType::ordered_by_dest)->GetFileType() !=
+                 graphar::FileType::PARQUET))
+            return false;
         return true;
     };
-    
-    ReadBase<ReadEdges>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate, vertex_num);
+
+    ReadBase<ReadEdges>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate);
 }
 //-------------------------------------------------------------------
 // InitFunction

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -254,21 +254,29 @@ void ReadEdges::PushdownComplexFilter(ClientContext& context, LogicalGet& get, F
     filters = std::move(filters_new);
 }
 //-------------------------------------------------------------------
-// GetFunction
+// InitFunction
 //-------------------------------------------------------------------
-TableFunction ReadEdges::GetFunction() {
-    TableFunction read_edges("read_edges", {LogicalType::VARCHAR}, Execute, Bind);
+static void InitFunction(TableFunction& read_edges) {
     read_edges.init_global = ReadEdges::Init;
     read_edges.init_local = ReadEdges::InitLocal;
-
-    read_edges.named_parameters["src"] = LogicalType::VARCHAR;
-    read_edges.named_parameters["dst"] = LogicalType::VARCHAR;
-    read_edges.named_parameters["type"] = LogicalType::VARCHAR;
 
     read_edges.filter_pushdown = false;
     read_edges.projection_pushdown = true;
     read_edges.statistics = ReadEdges::GetStatistics;
     read_edges.pushdown_complex_filter = ReadEdges::PushdownComplexFilter;
+
+    read_edges.get_partition_data = ReadBase<ReadEdges>::GetPartitionData;
+}
+//-------------------------------------------------------------------
+// GetFunction
+//-------------------------------------------------------------------
+TableFunction ReadEdges::GetFunction() {
+    TableFunction read_edges("read_edges", {LogicalType::VARCHAR}, Execute, Bind);
+    InitFunction(read_edges);
+
+    read_edges.named_parameters["src"] = LogicalType::VARCHAR;
+    read_edges.named_parameters["dst"] = LogicalType::VARCHAR;
+    read_edges.named_parameters["type"] = LogicalType::VARCHAR;
 
     return read_edges;
 }
@@ -277,13 +285,7 @@ TableFunction ReadEdges::GetFunction() {
 //-------------------------------------------------------------------
 TableFunction ReadEdges::GetScanFunction() {
     TableFunction read_edges({}, Execute, Bind);
-    read_edges.init_global = ReadEdges::Init;
-    read_edges.init_local = ReadEdges::InitLocal;
-
-    read_edges.filter_pushdown = false;
-    read_edges.projection_pushdown = true;
-    read_edges.statistics = ReadEdges::GetStatistics;
-    read_edges.pushdown_complex_filter = ReadEdges::PushdownComplexFilter;
+    InitFunction(read_edges);
 
     return read_edges;
 }

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -9,6 +9,9 @@
 #include <duckdb/function/table/arrow.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
+#include <duckdb/planner/expression/bound_operator_expression.hpp>
 
 #include <graphar/api/arrow_reader.h>
 #include <graphar/api/high_level_reader.h>
@@ -16,8 +19,6 @@
 #include <graphar/expression.h>
 #include <graphar/filesystem.h>
 #include <graphar/fwd.h>
-
-#include <iostream>
 
 namespace duckdb {
 //-------------------------------------------------------------------
@@ -77,7 +78,8 @@ unique_ptr<FunctionData> ReadVertices::Bind(ClientContext& context, TableFunctio
 // GetBaseReader
 //-------------------------------------------------------------------
 BaseReaderPtr ReadVertices::GetBaseReader(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                                          const std::string& filter_column) {
+                                          const std::string& filter_column,
+                                          std::shared_ptr<graphar::SharedChunkCounter> counter) {
     DUCKDB_GRAPHAR_LOG_TRACE("ReadVertices::GetBaseReader");
     auto vertex_info = *std::get_if<std::shared_ptr<graphar::VertexInfo>>(&gstate.type_info);
     if (!vertex_info) {
@@ -86,28 +88,33 @@ BaseReaderPtr ReadVertices::GetBaseReader(ClientContext& context, ReadBaseGlobal
     const auto& prefix = gstate.graph_info->GetPrefix();
     if (gstate.pgs[ind]->GetFileType() == graphar::FileType::PARQUET) {
         DUCKDB_GRAPHAR_LOG_DEBUG("Making duckdb reader");
-        return ConvertBaseReader(graphar::VertexPropertyChunkInfoReader::Make(vertex_info, gstate.pgs[ind], prefix));
+        return ConvertBaseReader(graphar::VertexPropertyChunkInfoReader::Make(vertex_info, gstate.pgs[ind], prefix),
+                                 counter);
     } else {
         DUCKDB_GRAPHAR_LOG_DEBUG("Making arrow reader");
-        return ConvertBaseReader(graphar::VertexPropertyArrowChunkReader::Make(vertex_info, gstate.pgs[ind], prefix));
+        return ConvertBaseReader(graphar::VertexPropertyArrowChunkReader::Make(vertex_info, gstate.pgs[ind], prefix),
+                                 counter);
     }
 }
 //-------------------------------------------------------------------
 // SetFilter
 //-------------------------------------------------------------------
 void ReadVertices::SetFilter(ClientContext& context, ReadBaseGlobalTableFunctionState& gstate, idx_t ind,
-                             const std::pair<int64_t, int64_t>& vid_range, const std::string& filter_column) {
+                             const vector<std::pair<int64_t, int64_t>>& vid_ranges, const std::string& filter_column) {
     DUCKDB_GRAPHAR_LOG_TRACE("ReadVertices::SetFilter");
     auto vertex_info = *std::get_if<std::shared_ptr<graphar::VertexInfo>>(&gstate.type_info);
     if (!vertex_info) {
         throw InternalException("Failed to get vertex info");
     }
     int64_t vertex_num = GetCountClass::GetCount(vertex_info, gstate.graph_info->GetPrefix());
-    if (vid_range.first < 0 || vid_range.first >= vertex_num || vid_range.second <= 0 ||
-        vid_range.second > vertex_num) {
-        throw BinderException("Invalid filter vertex id range");
+    for (idx_t r = 0; r < vid_ranges.size(); ++r) {
+        const auto& vid_range = vid_ranges[r];
+        if (vid_range.first < 0 || vid_range.first >= vertex_num || vid_range.second <= 0 ||
+            vid_range.second > vertex_num) {
+            throw BinderException("Invalid filter vertex id range");
+        }
+        FilterByRangeVertex(gstate.base_readers[ind][r], vid_range, filter_column, vertex_info);
     }
-    FilterByRangeVertex(gstate.base_readers[ind], vid_range, filter_column, vertex_info);
 }
 //-------------------------------------------------------------------
 // GetReader
@@ -123,15 +130,21 @@ ReaderPtr ReadVertices::GetReader(ClientContext& context, ReadBaseGlobalTableFun
     const auto& prefix = gstate.graph_info->GetPrefix();
     if (gstate.pgs[ind]->GetFileType() == graphar::FileType::PARQUET) {
         DUCKDB_GRAPHAR_LOG_DEBUG("Making duckdb reader");
-        auto base_reader =
-            std::get<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>>(gstate.base_readers[ind]);
+        std::vector<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>> base_readers;
+        base_readers.reserve(gstate.base_readers[ind].size());
+        for (const auto& base_reader : gstate.base_readers[ind]) {
+            base_readers.push_back(std::get<std::shared_ptr<graphar::TSVertexPropertyChunkInfoReader>>(base_reader));
+        }
         return ConvertReader(graphar::DuckVertexPropertyChunkReader::Make(context, lstate.file_reader, vertex_info,
-                                                                          gstate.pgs[ind], prefix, base_reader));
+                                                                          gstate.pgs[ind], prefix, base_readers));
     } else {
         DUCKDB_GRAPHAR_LOG_DEBUG("Making arrow reader");
-        auto base_reader =
-            std::get<std::shared_ptr<graphar::TSVertexPropertyArrowChunkReader>>(gstate.base_readers[ind]);
-        return ConvertReader(graphar::DuckVertexPropertyArrowChunkReader::Make(context, base_reader));
+        std::vector<std::shared_ptr<graphar::TSVertexPropertyArrowChunkReader>> base_readers;
+        base_readers.reserve(gstate.base_readers[ind].size());
+        for (const auto& base_reader : gstate.base_readers[ind]) {
+            base_readers.push_back(std::get<std::shared_ptr<graphar::TSVertexPropertyArrowChunkReader>>(base_reader));
+        }
+        return ConvertReader(graphar::DuckVertexPropertyArrowChunkReader::Make(context, base_readers));
     }
 }
 //-------------------------------------------------------------------
@@ -161,7 +174,6 @@ void ReadVertices::PushdownComplexFilter(ClientContext& context, LogicalGet& get
     auto read_bind_data = dynamic_cast<ReadBindData*>(bind_data);
     for (auto& pg : read_bind_data->pgs) {
         if (pg->GetFileType() != graphar::FileType::PARQUET) {
-            // our pushdown works greatly only for parquet files
             return;
         }
     }
@@ -183,8 +195,39 @@ void ReadVertices::PushdownComplexFilter(ClientContext& context, LogicalGet& get
                     if (column_name == GID_COLUMN_INTERNAL) {
                         can_pushdown = true;
                         const auto vid = std::stoll(comparison.right->ToString());
-                        read_bind_data->vid_range = std::make_pair(vid, vid + 1);
+                        read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
                         read_bind_data->filter_column = column_name;
+                    }
+                }
+            }
+        }
+        if (filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+            auto& op_expr = filter->Cast<BoundFunctionExpression>();
+            if (op_expr.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
+                if (op_expr.children.size() != 2) {
+                    continue;
+                }
+                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                    auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
+                    auto column_name = op_expr.children[1]->ToString();
+                    if (column_name == GID_COLUMN_INTERNAL) {
+                        std::vector<int64_t> vids;
+                        auto& list_value = const_expr.value;
+                        if (list_value.type().id() == LogicalTypeId::LIST) {
+                            auto children = ListValue::GetChildren(list_value);
+                            for (const auto& child : children) {
+                                if (!child.IsNull()) {
+                                    vids.push_back(child.GetValue<int64_t>());
+                                }
+                            }
+                        }
+                        if (!vids.empty()) {
+                            can_pushdown = true;
+                            for (const auto vid : vids) {
+                                read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
+                            }
+                            read_bind_data->filter_column = column_name;
+                        }
                     }
                 }
             }

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -3,8 +3,6 @@
 #include "utils/benchmark.hpp"
 #include "utils/func.hpp"
 
-#include <set>
-
 #include <arrow/c/bridge.h>
 
 #include <duckdb/common/named_parameter_map.hpp>
@@ -21,6 +19,8 @@
 #include <graphar/expression.h>
 #include <graphar/filesystem.h>
 #include <graphar/fwd.h>
+
+#include <set>
 
 namespace duckdb {
 //-------------------------------------------------------------------
@@ -179,17 +179,14 @@ void ReadVertices::PushdownComplexFilter(ClientContext& context, LogicalGet& get
             return;
         }
     }
-    
-    auto vertex_info = *std::get_if<std::shared_ptr<graphar::VertexInfo>>(&read_bind_data->type_info);
-    const auto vertex_num = GetCountClass::GetCount(read_bind_data->type_info, read_bind_data->GetGraphInfo()->GetPrefix());
-    
+
     // Validation lambda for vertices
     auto validate = [&](const std::string& col, const Value& val) -> bool {
         if (col != GID_COLUMN_INTERNAL) return false;
         return true;
     };
-    
-    ReadBase<ReadVertices>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate, vertex_num);
+
+    ReadBase<ReadVertices>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate);
 }
 //-------------------------------------------------------------------
 // InitFunction

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -3,6 +3,8 @@
 #include "utils/benchmark.hpp"
 #include "utils/func.hpp"
 
+#include <set>
+
 #include <arrow/c/bridge.h>
 
 #include <duckdb/common/named_parameter_map.hpp>
@@ -177,67 +179,17 @@ void ReadVertices::PushdownComplexFilter(ClientContext& context, LogicalGet& get
             return;
         }
     }
-    vector<unique_ptr<Expression>> filters_new;
-    bool already_pushed = false;
-    for (auto& filter : filters) {
-        if (already_pushed) {
-            filters_new.push_back(std::move(filter));
-            continue;
-        }
-        bool can_pushdown = false;
-        if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-            auto& comparison = filter->Cast<BoundComparisonExpression>();
-            if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
-                bool left_is_scalar = comparison.left->IsFoldable();
-                bool right_is_scalar = comparison.right->IsFoldable();
-                if (left_is_scalar || right_is_scalar) {
-                    auto column_name = comparison.left->ToString();
-                    if (column_name == GID_COLUMN_INTERNAL) {
-                        can_pushdown = true;
-                        const auto vid = std::stoll(comparison.right->ToString());
-                        read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
-                        read_bind_data->filter_column = column_name;
-                    }
-                }
-            }
-        }
-        if (filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-            auto& op_expr = filter->Cast<BoundFunctionExpression>();
-            if (op_expr.GetExpressionType() == ExpressionType::BOUND_FUNCTION) {
-                if (op_expr.children.size() != 2) {
-                    continue;
-                }
-                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                    auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
-                    auto column_name = op_expr.children[1]->ToString();
-                    if (column_name == GID_COLUMN_INTERNAL) {
-                        std::vector<int64_t> vids;
-                        auto& list_value = const_expr.value;
-                        if (list_value.type().id() == LogicalTypeId::LIST) {
-                            auto children = ListValue::GetChildren(list_value);
-                            for (const auto& child : children) {
-                                if (!child.IsNull()) {
-                                    vids.push_back(child.GetValue<int64_t>());
-                                }
-                            }
-                        }
-                        if (!vids.empty()) {
-                            can_pushdown = true;
-                            for (const auto vid : vids) {
-                                read_bind_data->vid_ranges.push_back(std::make_pair(vid, vid + 1));
-                            }
-                            read_bind_data->filter_column = column_name;
-                        }
-                    }
-                }
-            }
-        }
-        if (!can_pushdown) {
-            already_pushed = true;
-            filters_new.push_back(std::move(filter));
-        }
-    }
-    filters = std::move(filters_new);
+    
+    auto vertex_info = *std::get_if<std::shared_ptr<graphar::VertexInfo>>(&read_bind_data->type_info);
+    const auto vertex_num = GetCountClass::GetCount(read_bind_data->type_info, read_bind_data->GetGraphInfo()->GetPrefix());
+    
+    // Validation lambda for vertices
+    auto validate = [&](const std::string& col, const Value& val) -> bool {
+        if (col != GID_COLUMN_INTERNAL) return false;
+        return true;
+    };
+    
+    ReadBase<ReadVertices>::PushdownComplexFilterImpl(context, *read_bind_data, filters, validate, vertex_num);
 }
 //-------------------------------------------------------------------
 // InitFunction

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -197,19 +197,27 @@ void ReadVertices::PushdownComplexFilter(ClientContext& context, LogicalGet& get
     filters = std::move(filters_new);
 }
 //-------------------------------------------------------------------
-// GetFunction
+// InitFunction
 //-------------------------------------------------------------------
-TableFunction ReadVertices::GetFunction() {
-    TableFunction read_vertices("read_vertices", {LogicalType::VARCHAR}, Execute, Bind);
+static void InitFunction(TableFunction& read_vertices) {
     read_vertices.init_global = ReadVertices::Init;
     read_vertices.init_local = ReadVertices::InitLocal;
-
-    read_vertices.named_parameters["type"] = LogicalType::VARCHAR;
 
     read_vertices.filter_pushdown = false;
     read_vertices.projection_pushdown = true;
     read_vertices.statistics = ReadVertices::GetStatistics;
     read_vertices.pushdown_complex_filter = ReadVertices::PushdownComplexFilter;
+
+    read_vertices.get_partition_data = ReadBase<ReadVertices>::GetPartitionData;
+}
+//-------------------------------------------------------------------
+// GetFunction
+//-------------------------------------------------------------------
+TableFunction ReadVertices::GetFunction() {
+    TableFunction read_vertices("read_vertices", {LogicalType::VARCHAR}, Execute, Bind);
+    InitFunction(read_vertices);
+
+    read_vertices.named_parameters["type"] = LogicalType::VARCHAR;
 
     return read_vertices;
 }
@@ -218,13 +226,7 @@ TableFunction ReadVertices::GetFunction() {
 //-------------------------------------------------------------------
 TableFunction ReadVertices::GetScanFunction() {
     TableFunction read_vertices({}, Execute, Bind);
-    read_vertices.init_global = ReadVertices::Init;
-    read_vertices.init_local = ReadVertices::InitLocal;
-
-    read_vertices.filter_pushdown = false;
-    read_vertices.projection_pushdown = true;
-    read_vertices.statistics = ReadVertices::GetStatistics;
-    read_vertices.pushdown_complex_filter = ReadVertices::PushdownComplexFilter;
+    InitFunction(read_vertices);
 
     return read_vertices;
 }

--- a/src/readers/duck_chunk_reader.cpp
+++ b/src/readers/duck_chunk_reader.cpp
@@ -50,7 +50,6 @@ std::string QueryStringConstructor::GetMainQueryString(const std::vector<column_
                     // No WHERE clause needed
                     break;
             }
-            ss << " " << SQL_ORDER_BY_CLAUSE;
             break;
         default:
             throw NotImplementedException("Unsupported file format");

--- a/src/readers/duck_chunk_reader.cpp
+++ b/src/readers/duck_chunk_reader.cpp
@@ -9,6 +9,7 @@ constexpr std::string_view SQL_LIMIT_CLAUSE = "LIMIT";
 constexpr std::string_view SQL_OFFSET_CLAUSE = "OFFSET";
 constexpr std::string_view READ_PARQUET_FUNCTION = "read_parquet";
 constexpr std::string_view FILE_ROW_NUMBER_CLAUSE = "file_row_number";
+constexpr std::string_view SQL_ORDER_BY_CLAUSE = "ORDER BY file_row_number";
 }  // namespace
 
 namespace duckdb {
@@ -49,6 +50,7 @@ std::string QueryStringConstructor::GetMainQueryString(const std::vector<column_
                     // No WHERE clause needed
                     break;
             }
+            ss << " " << SQL_ORDER_BY_CLAUSE;
             break;
         default:
             throw NotImplementedException("Unsupported file format");


### PR DESCRIPTION
Changes
Added support for filtering with multiple vertex ID ranges (IN clause) for Duck vertices and edges readers. Creates separate thread-safe readers per VID range with shared chunk counter. Also added partition data usage to fix chunk order in multithread execution.

Example
ATTACH 'graph.yaml' (type duckdb_graphar);

SELECT * FROM Person WHERE _graphArVertexIndex IN [0, 1, 2];
SELECT * FROM Person_knows_Person WHERE _graphArSrcIndex IN [5, 10, 15];
SELECT COUNT(*) FROM Person_knows_Person WHERE _graphArSrcIndex IN [100, 11];