### PR TITLE
feat(reading): Add GraphAr column statistics support for read functions

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -19,12 +19,12 @@ set(DEPS_INSTALL_DIR ${CMAKE_BINARY_DIR}/_deps)
 set(ARROW_INSTALL_DIR ${DEPS_INSTALL_DIR}/arrow-install)
 set(GRAPHAR_INSTALL_DIR ${DEPS_INSTALL_DIR}/graphar-install)
 
-set(GRAPHAR_SOURCE_DIR ${DEPS_INSTALL_DIR}/graphar-src)
+set(GRAPHAR_SOURCE_DIR ${DEPS_INSTALL_DIR}/graphar-prefix/src)
 
 set(EXTENSION_INCLUDES
     $<BUILD_INTERFACE:${EXTENSION_ROOT_DIR}/include>
     $<BUILD_INTERFACE:${GRAPHAR_INSTALL_DIR}/include>
-    $<BUILD_INTERFACE:${GRAPHAR_SOURCE_DIR}/cpp/thirdparty>
+    $<BUILD_INTERFACE:${GRAPHAR_SOURCE_DIR}/graphar/cpp/thirdparty>
     $<BUILD_INTERFACE:${duckdb_SOURCE_DIR}/src/include>
     $<BUILD_INTERFACE:${arrow_SOURCE_DIR}/cpp/src>
     $<BUILD_INTERFACE:${ARROW_INSTALL_DIR}/include>

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -227,105 +227,71 @@ private:
 template <typename ReadFinal>
 class ReadBase {
 private:
+    static bool IsValidInteger(const std::string& s) {
+        if (s.empty()) return false;
+        size_t start = 0;
+        if (s[0] == '-' || s[0] == '+') start = 1;
+        if (start >= s.size()) return false;
+        for (size_t i = start; i < s.size(); i++) {
+            if (!std::isdigit(static_cast<unsigned char>(s[i]))) return false;
+        }
+        return true;
+    }
+
+    static bool IsValidFloat(const std::string& s) {
+        if (s.empty()) return false;
+        const char* start = s.c_str();
+        char* end = nullptr;
+        double val = std::strtod(start, &end);
+        return (end != start && *end == '\0' && std::isfinite(val));
+    }
+
+    template <typename T>
+    static bool ValidateAndConvertIntegerStats(const std::string& min_str, const std::string& max_str,
+                                               Value& out_min, Value& out_max, Value (*creator)(T)) {
+        if (!IsValidInteger(min_str) || !IsValidInteger(max_str)) return false;
+        int64_t min_val = std::stoll(min_str);
+        int64_t max_val = std::stoll(max_str);
+        if (min_val > max_val) return false;
+        if (min_val < std::numeric_limits<T>::min() || min_val > std::numeric_limits<T>::max()) return false;
+        if (max_val < std::numeric_limits<T>::min() || max_val > std::numeric_limits<T>::max()) return false;
+        out_min = creator(static_cast<T>(min_val));
+        out_max = creator(static_cast<T>(max_val));
+        return true;
+    }
+
+    template <typename T>
+    static bool ValidateAndConvertFloatStats(const std::string& min_str, const std::string& max_str,
+                                             Value& out_min, Value& out_max, Value (*creator)(T)) {
+        if (!IsValidFloat(min_str) || !IsValidFloat(max_str)) return false;
+        T min_val = static_cast<T>(std::stod(min_str));
+        T max_val = static_cast<T>(std::stod(max_str));
+        if (min_val > max_val) return false;
+        out_min = creator(min_val);
+        out_max = creator(max_val);
+        return true;
+    }
+
     static bool ValidateAndConvertStats(const std::string& min_str, const std::string& max_str,
                                         const LogicalType& duck_type, Value& out_min, Value& out_max) {
         if (min_str.empty() || max_str.empty()) {
             return false;
         }
 
-        auto is_valid_integer = [](const std::string& s) -> bool {
-            if (s.empty()) return false;
-            size_t start = 0;
-            if (s[0] == '-' || s[0] == '+') start = 1;
-            if (start >= s.size()) return false;
-            for (size_t i = start; i < s.size(); i++) {
-                if (!std::isdigit(static_cast<unsigned char>(s[i]))) return false;
-            }
-            return true;
-        };
-
-        auto is_valid_float = [](const std::string& s) -> bool {
-            if (s.empty()) return false;
-            bool has_dot = false;
-            bool has_digit = false;
-            size_t start = 0;
-            if (s[0] == '-' || s[0] == '+') start = 1;
-            if (start >= s.size()) return false;
-            for (size_t i = start; i < s.size(); i++) {
-                if (s[i] == '.') {
-                    if (has_dot) return false;
-                    has_dot = true;
-                } else if (std::isdigit(static_cast<unsigned char>(s[i]))) {
-                    has_digit = true;
-                } else {
-                    return false;
-                }
-            }
-            return has_digit;
-        };
-
         try {
             switch (duck_type.id()) {
-                case LogicalTypeId::TINYINT: {
-                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                    int64_t min_val = std::stoll(min_str);
-                    int64_t max_val = std::stoll(max_str);
-                    if (min_val < std::numeric_limits<int8_t>::min() || min_val > std::numeric_limits<int8_t>::max())
-                        return false;
-                    if (max_val < std::numeric_limits<int8_t>::min() || max_val > std::numeric_limits<int8_t>::max())
-                        return false;
-                    out_min = Value::TINYINT(static_cast<int8_t>(min_val));
-                    out_max = Value::TINYINT(static_cast<int8_t>(max_val));
-                    return true;
-                }
-                case LogicalTypeId::SMALLINT: {
-                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                    int64_t min_val = std::stoll(min_str);
-                    int64_t max_val = std::stoll(max_str);
-                    if (min_val < std::numeric_limits<int16_t>::min() || min_val > std::numeric_limits<int16_t>::max())
-                        return false;
-                    if (max_val < std::numeric_limits<int16_t>::min() || max_val > std::numeric_limits<int16_t>::max())
-                        return false;
-                    out_min = Value::SMALLINT(static_cast<int16_t>(min_val));
-                    out_max = Value::SMALLINT(static_cast<int16_t>(max_val));
-                    return true;
-                }
-                case LogicalTypeId::INTEGER: {
-                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                    int64_t min_val = std::stoll(min_str);
-                    int64_t max_val = std::stoll(max_str);
-                    if (min_val < std::numeric_limits<int32_t>::min() || min_val > std::numeric_limits<int32_t>::max())
-                        return false;
-                    if (max_val < std::numeric_limits<int32_t>::min() || max_val > std::numeric_limits<int32_t>::max())
-                        return false;
-                    out_min = Value::INTEGER(static_cast<int32_t>(min_val));
-                    out_max = Value::INTEGER(static_cast<int32_t>(max_val));
-                    return true;
-                }
-                case LogicalTypeId::BIGINT: {
-                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                    int64_t min_val = std::stoll(min_str);
-                    int64_t max_val = std::stoll(max_str);
-                    out_min = Value::BIGINT(min_val);
-                    out_max = Value::BIGINT(max_val);
-                    return true;
-                }
-                case LogicalTypeId::FLOAT: {
-                    if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
-                    float min_val = std::stof(min_str);
-                    float max_val = std::stof(max_str);
-                    out_min = Value::FLOAT(min_val);
-                    out_max = Value::FLOAT(max_val);
-                    return true;
-                }
-                case LogicalTypeId::DOUBLE: {
-                    if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
-                    double min_val = std::stod(min_str);
-                    double max_val = std::stod(max_str);
-                    out_min = Value::DOUBLE(min_val);
-                    out_max = Value::DOUBLE(max_val);
-                    return true;
-                }
+                case LogicalTypeId::TINYINT:
+                    return ValidateAndConvertIntegerStats<int8_t>(min_str, max_str, out_min, out_max, Value::TINYINT);
+                case LogicalTypeId::SMALLINT:
+                    return ValidateAndConvertIntegerStats<int16_t>(min_str, max_str, out_min, out_max, Value::SMALLINT);
+                case LogicalTypeId::INTEGER:
+                    return ValidateAndConvertIntegerStats<int32_t>(min_str, max_str, out_min, out_max, Value::INTEGER);
+                case LogicalTypeId::BIGINT:
+                    return ValidateAndConvertIntegerStats<int64_t>(min_str, max_str, out_min, out_max, Value::BIGINT);
+                case LogicalTypeId::FLOAT:
+                    return ValidateAndConvertFloatStats<float>(min_str, max_str, out_min, out_max, Value::FLOAT);
+                case LogicalTypeId::DOUBLE:
+                    return ValidateAndConvertFloatStats<double>(min_str, max_str, out_min, out_max, Value::DOUBLE);
                 default:
                     return false;
             }

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -31,8 +31,10 @@
 #include <graphar/reader_util.h>
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <iostream>
+#include <limits>
 #include <mini-yaml/yaml/Yaml.hpp>
 #include <sstream>
 #include <unordered_map>
@@ -237,7 +239,7 @@ private:
             if (s[0] == '-' || s[0] == '+') start = 1;
             if (start >= s.size()) return false;
             for (size_t i = start; i < s.size(); i++) {
-                if (!isdigit(s[i])) return false;
+                if (!std::isdigit(static_cast<unsigned char>(s[i]))) return false;
             }
             return true;
         };
@@ -253,7 +255,7 @@ private:
                 if (s[i] == '.') {
                     if (has_dot) return false;
                     has_dot = true;
-                } else if (isdigit(s[i])) {
+                } else if (std::isdigit(static_cast<unsigned char>(s[i]))) {
                     has_digit = true;
                 } else {
                     return false;

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -247,8 +247,8 @@ private:
     }
 
     template <typename T>
-    static bool ValidateAndConvertIntegerStats(const std::string& min_str, const std::string& max_str,
-                                               Value& out_min, Value& out_max, Value (*creator)(T)) {
+    static bool ValidateAndConvertIntegerStats(const std::string& min_str, const std::string& max_str, Value& out_min,
+                                               Value& out_max, Value (*creator)(T)) {
         if (!IsValidInteger(min_str) || !IsValidInteger(max_str)) return false;
         int64_t min_val = std::stoll(min_str);
         int64_t max_val = std::stoll(max_str);
@@ -261,8 +261,8 @@ private:
     }
 
     template <typename T>
-    static bool ValidateAndConvertFloatStats(const std::string& min_str, const std::string& max_str,
-                                             Value& out_min, Value& out_max, Value (*creator)(T)) {
+    static bool ValidateAndConvertFloatStats(const std::string& min_str, const std::string& max_str, Value& out_min,
+                                             Value& out_max, Value (*creator)(T)) {
         if (!IsValidFloat(min_str) || !IsValidFloat(max_str)) return false;
         T min_val = static_cast<T>(std::stod(min_str));
         T max_val = static_cast<T>(std::stod(max_str));

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -387,7 +387,7 @@ public:
     static const vector<std::pair<graphar::IdType, graphar::IdType>>& GetVidRanges(const ReadBindData& bind_data) {
         return bind_data.vid_ranges;
     }
-    
+
     static unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, const FunctionData* bind_data,
                                                     column_t column_index) {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadBase::GetStatistics");

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -139,8 +139,8 @@ class ReadEdges;
 
 struct ColumnStats {
     bool has_min_max = false;
-    std::string min_val;
-    std::string max_val;
+    Value min_val;
+    Value max_val;
     bool is_nullable = true;
 };
 
@@ -148,10 +148,10 @@ class ReadBindData : public TableFunctionData {
 public:
     ReadBindData() = default;
     vector<std::string> GetParams() { return params; }
-    vector<std::string>& GetFlattenPropNames() { return flatten_prop_names; }
-    vector<std::string>& GetFlattenPropTypes() { return flatten_prop_types; }
+    const vector<std::string>& GetFlattenPropNames() const { return flatten_prop_names; }
+    const vector<std::string>& GetFlattenPropTypes() const { return flatten_prop_types; }
     const std::shared_ptr<graphar::GraphInfo>& GetGraphInfo() const { return graph_info; }
-    std::unordered_map<std::string, ColumnStats>& GetStatsMap() { return stats_map; }
+    const std::unordered_map<std::string, ColumnStats>& GetStatsMap() const { return stats_map; }
 
 private:
     vector<vector<std::string>> prop_names;
@@ -224,6 +224,110 @@ private:
 
 template <typename ReadFinal>
 class ReadBase {
+private:
+    static bool ValidateAndConvertStats(const std::string& min_str, const std::string& max_str,
+                                        const LogicalType& duck_type, Value& out_min, Value& out_max) {
+        if (min_str.empty() || max_str.empty()) {
+            return false;
+        }
+
+        auto is_valid_integer = [](const std::string& s) -> bool {
+            if (s.empty()) return false;
+            size_t start = 0;
+            if (s[0] == '-' || s[0] == '+') start = 1;
+            if (start >= s.size()) return false;
+            for (size_t i = start; i < s.size(); i++) {
+                if (!isdigit(s[i])) return false;
+            }
+            return true;
+        };
+
+        auto is_valid_float = [](const std::string& s) -> bool {
+            if (s.empty()) return false;
+            bool has_dot = false;
+            bool has_digit = false;
+            size_t start = 0;
+            if (s[0] == '-' || s[0] == '+') start = 1;
+            if (start >= s.size()) return false;
+            for (size_t i = start; i < s.size(); i++) {
+                if (s[i] == '.') {
+                    if (has_dot) return false;
+                    has_dot = true;
+                } else if (isdigit(s[i])) {
+                    has_digit = true;
+                } else {
+                    return false;
+                }
+            }
+            return has_digit;
+        };
+
+        switch (duck_type.id()) {
+            case LogicalTypeId::TINYINT: {
+                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                int64_t min_val = std::stoll(min_str);
+                int64_t max_val = std::stoll(max_str);
+                if (min_val < std::numeric_limits<int8_t>::min() || min_val > std::numeric_limits<int8_t>::max())
+                    return false;
+                if (max_val < std::numeric_limits<int8_t>::min() || max_val > std::numeric_limits<int8_t>::max())
+                    return false;
+                out_min = Value::TINYINT(static_cast<int8_t>(min_val));
+                out_max = Value::TINYINT(static_cast<int8_t>(max_val));
+                return true;
+            }
+            case LogicalTypeId::SMALLINT: {
+                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                int64_t min_val = std::stoll(min_str);
+                int64_t max_val = std::stoll(max_str);
+                if (min_val < std::numeric_limits<int16_t>::min() || min_val > std::numeric_limits<int16_t>::max())
+                    return false;
+                if (max_val < std::numeric_limits<int16_t>::min() || max_val > std::numeric_limits<int16_t>::max())
+                    return false;
+                out_min = Value::SMALLINT(static_cast<int16_t>(min_val));
+                out_max = Value::SMALLINT(static_cast<int16_t>(max_val));
+                return true;
+            }
+            case LogicalTypeId::INTEGER: {
+                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                int64_t min_val = std::stoll(min_str);
+                int64_t max_val = std::stoll(max_str);
+                if (min_val < std::numeric_limits<int32_t>::min() || min_val > std::numeric_limits<int32_t>::max())
+                    return false;
+                if (max_val < std::numeric_limits<int32_t>::min() || max_val > std::numeric_limits<int32_t>::max())
+                    return false;
+                out_min = Value::INTEGER(static_cast<int32_t>(min_val));
+                out_max = Value::INTEGER(static_cast<int32_t>(max_val));
+                return true;
+            }
+            case LogicalTypeId::BIGINT: {
+                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                int64_t min_val = std::stoll(min_str);
+                int64_t max_val = std::stoll(max_str);
+                out_min = Value::BIGINT(min_val);
+                out_max = Value::BIGINT(max_val);
+                return true;
+            }
+            case LogicalTypeId::FLOAT: {
+                if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
+                float min_val = std::stof(min_str);
+                float max_val = std::stof(max_str);
+                out_min = Value::FLOAT(min_val);
+                out_max = Value::FLOAT(max_val);
+                return true;
+            }
+            case LogicalTypeId::DOUBLE: {
+                if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
+                double min_val = std::stod(min_str);
+                double max_val = std::stod(max_str);
+                out_min = Value::DOUBLE(min_val);
+                out_max = Value::DOUBLE(max_val);
+                return true;
+            }
+            default:
+                return false;
+        }
+    }
+
 public:
     static void SetBindData(std::shared_ptr<graphar::GraphInfo> graph_info, TypeInfoPtr type_info,
                             unique_ptr<ReadBindData>& bind_data, string function_name, idx_t id_columns_num = 0,
@@ -346,9 +450,20 @@ public:
                                     }
 
                                     if (has_min && has_max) {
-                                        bind_data->stats_map[column_name].has_min_max = true;
-                                        bind_data->stats_map[column_name].min_val = min_val;
-                                        bind_data->stats_map[column_name].max_val = max_val;
+                                        auto it = std::find(bind_data->flatten_prop_names.begin(),
+                                                            bind_data->flatten_prop_names.end(), column_name);
+                                        if (it != bind_data->flatten_prop_names.end()) {
+                                            idx_t col_idx = it - bind_data->flatten_prop_names.begin();
+                                            auto duck_type = GraphArFunctions::graphArT2duckT(
+                                                bind_data->flatten_prop_types[col_idx]);
+                                            Value typed_min, typed_max;
+                                            if (ValidateAndConvertStats(min_val, max_val, duck_type, typed_min,
+                                                                        typed_max)) {
+                                                bind_data->stats_map[column_name].has_min_max = true;
+                                                bind_data->stats_map[column_name].min_val = typed_min;
+                                                bind_data->stats_map[column_name].max_val = typed_max;
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -391,7 +506,7 @@ public:
     static unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, const FunctionData* bind_data,
                                                     column_t column_index) {
         DUCKDB_GRAPHAR_LOG_TRACE("ReadBase::GetStatistics");
-        auto read_bind_data = bind_data->Cast<ReadBindData>();
+        auto& read_bind_data = bind_data->Cast<ReadBindData>();
         if (column_index < 0 || column_index >= read_bind_data.GetFlattenPropTypes().size()) {
             return nullptr;
         }
@@ -404,41 +519,13 @@ public:
             return BaseStatistics::CreateUnknown(duck_type).ToUnique();
         }
 
-        auto& c_stats = stats_map[column_name];
+        auto& c_stats = stats_map.at(column_name);
         auto stats = BaseStatistics::CreateUnknown(duck_type);
 
-        // 1. Initialize stats object and apply Min/Max values if available
         if (c_stats.has_min_max && LogicalType::IsNumeric(duck_type)) {
             stats = NumericStats::CreateEmpty(duck_type);
-            switch (duck_type) {
-                case LogicalTypeId::TINYINT:
-                    NumericStats::SetMin<int8_t>(stats, static_cast<int8_t>(std::stoi(c_stats.min_val)));
-                    NumericStats::SetMax<int8_t>(stats, static_cast<int8_t>(std::stoi(c_stats.max_val)));
-                    break;
-                case LogicalTypeId::SMALLINT:
-                    NumericStats::SetMin<int16_t>(stats, static_cast<int16_t>(std::stoi(c_stats.min_val)));
-                    NumericStats::SetMax<int16_t>(stats, static_cast<int16_t>(std::stoi(c_stats.max_val)));
-                    break;
-                case LogicalTypeId::INTEGER:
-                    NumericStats::SetMin<int32_t>(stats, static_cast<int32_t>(std::stoll(c_stats.min_val)));
-                    NumericStats::SetMax<int32_t>(stats, static_cast<int32_t>(std::stoll(c_stats.max_val)));
-                    break;
-                case LogicalTypeId::BIGINT:
-                    NumericStats::SetMin<int64_t>(stats, static_cast<int64_t>(std::stoll(c_stats.min_val)));
-                    NumericStats::SetMax<int64_t>(stats, static_cast<int64_t>(std::stoll(c_stats.max_val)));
-                    break;
-                case LogicalTypeId::FLOAT:
-                    NumericStats::SetMin<float>(stats, std::stof(c_stats.min_val));
-                    NumericStats::SetMax<float>(stats, std::stof(c_stats.max_val));
-                    break;
-                case LogicalTypeId::DOUBLE:
-                    NumericStats::SetMin<double>(stats, std::stod(c_stats.min_val));
-                    NumericStats::SetMax<double>(stats, std::stod(c_stats.max_val));
-                    break;
-                default:
-                    stats = BaseStatistics::CreateUnknown(duck_type);
-                    break;
-            }
+            NumericStats::SetMin(stats, c_stats.min_val);
+            NumericStats::SetMax(stats, c_stats.max_val);
         }
 
         // 2. Apply explicit nullability marker

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -264,69 +264,73 @@ private:
             return has_digit;
         };
 
-        switch (duck_type.id()) {
-            case LogicalTypeId::TINYINT: {
-                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                int64_t min_val = std::stoll(min_str);
-                int64_t max_val = std::stoll(max_str);
-                if (min_val < std::numeric_limits<int8_t>::min() || min_val > std::numeric_limits<int8_t>::max())
+        try {
+            switch (duck_type.id()) {
+                case LogicalTypeId::TINYINT: {
+                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                    int64_t min_val = std::stoll(min_str);
+                    int64_t max_val = std::stoll(max_str);
+                    if (min_val < std::numeric_limits<int8_t>::min() || min_val > std::numeric_limits<int8_t>::max())
+                        return false;
+                    if (max_val < std::numeric_limits<int8_t>::min() || max_val > std::numeric_limits<int8_t>::max())
+                        return false;
+                    out_min = Value::TINYINT(static_cast<int8_t>(min_val));
+                    out_max = Value::TINYINT(static_cast<int8_t>(max_val));
+                    return true;
+                }
+                case LogicalTypeId::SMALLINT: {
+                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                    int64_t min_val = std::stoll(min_str);
+                    int64_t max_val = std::stoll(max_str);
+                    if (min_val < std::numeric_limits<int16_t>::min() || min_val > std::numeric_limits<int16_t>::max())
+                        return false;
+                    if (max_val < std::numeric_limits<int16_t>::min() || max_val > std::numeric_limits<int16_t>::max())
+                        return false;
+                    out_min = Value::SMALLINT(static_cast<int16_t>(min_val));
+                    out_max = Value::SMALLINT(static_cast<int16_t>(max_val));
+                    return true;
+                }
+                case LogicalTypeId::INTEGER: {
+                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                    int64_t min_val = std::stoll(min_str);
+                    int64_t max_val = std::stoll(max_str);
+                    if (min_val < std::numeric_limits<int32_t>::min() || min_val > std::numeric_limits<int32_t>::max())
+                        return false;
+                    if (max_val < std::numeric_limits<int32_t>::min() || max_val > std::numeric_limits<int32_t>::max())
+                        return false;
+                    out_min = Value::INTEGER(static_cast<int32_t>(min_val));
+                    out_max = Value::INTEGER(static_cast<int32_t>(max_val));
+                    return true;
+                }
+                case LogicalTypeId::BIGINT: {
+                    if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
+                    int64_t min_val = std::stoll(min_str);
+                    int64_t max_val = std::stoll(max_str);
+                    out_min = Value::BIGINT(min_val);
+                    out_max = Value::BIGINT(max_val);
+                    return true;
+                }
+                case LogicalTypeId::FLOAT: {
+                    if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
+                    float min_val = std::stof(min_str);
+                    float max_val = std::stof(max_str);
+                    out_min = Value::FLOAT(min_val);
+                    out_max = Value::FLOAT(max_val);
+                    return true;
+                }
+                case LogicalTypeId::DOUBLE: {
+                    if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
+                    double min_val = std::stod(min_str);
+                    double max_val = std::stod(max_str);
+                    out_min = Value::DOUBLE(min_val);
+                    out_max = Value::DOUBLE(max_val);
+                    return true;
+                }
+                default:
                     return false;
-                if (max_val < std::numeric_limits<int8_t>::min() || max_val > std::numeric_limits<int8_t>::max())
-                    return false;
-                out_min = Value::TINYINT(static_cast<int8_t>(min_val));
-                out_max = Value::TINYINT(static_cast<int8_t>(max_val));
-                return true;
             }
-            case LogicalTypeId::SMALLINT: {
-                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                int64_t min_val = std::stoll(min_str);
-                int64_t max_val = std::stoll(max_str);
-                if (min_val < std::numeric_limits<int16_t>::min() || min_val > std::numeric_limits<int16_t>::max())
-                    return false;
-                if (max_val < std::numeric_limits<int16_t>::min() || max_val > std::numeric_limits<int16_t>::max())
-                    return false;
-                out_min = Value::SMALLINT(static_cast<int16_t>(min_val));
-                out_max = Value::SMALLINT(static_cast<int16_t>(max_val));
-                return true;
-            }
-            case LogicalTypeId::INTEGER: {
-                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                int64_t min_val = std::stoll(min_str);
-                int64_t max_val = std::stoll(max_str);
-                if (min_val < std::numeric_limits<int32_t>::min() || min_val > std::numeric_limits<int32_t>::max())
-                    return false;
-                if (max_val < std::numeric_limits<int32_t>::min() || max_val > std::numeric_limits<int32_t>::max())
-                    return false;
-                out_min = Value::INTEGER(static_cast<int32_t>(min_val));
-                out_max = Value::INTEGER(static_cast<int32_t>(max_val));
-                return true;
-            }
-            case LogicalTypeId::BIGINT: {
-                if (!is_valid_integer(min_str) || !is_valid_integer(max_str)) return false;
-                int64_t min_val = std::stoll(min_str);
-                int64_t max_val = std::stoll(max_str);
-                out_min = Value::BIGINT(min_val);
-                out_max = Value::BIGINT(max_val);
-                return true;
-            }
-            case LogicalTypeId::FLOAT: {
-                if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
-                float min_val = std::stof(min_str);
-                float max_val = std::stof(max_str);
-                out_min = Value::FLOAT(min_val);
-                out_max = Value::FLOAT(max_val);
-                return true;
-            }
-            case LogicalTypeId::DOUBLE: {
-                if (!is_valid_float(min_str) || !is_valid_float(max_str)) return false;
-                double min_val = std::stod(min_str);
-                double max_val = std::stod(max_str);
-                out_min = Value::DOUBLE(min_val);
-                out_max = Value::DOUBLE(max_val);
-                return true;
-            }
-            default:
-                return false;
+        } catch (const std::exception&) {
+            return false;
         }
     }
 

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -20,6 +20,7 @@
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/planner/expression/bound_operator_expression.hpp>
+#include <duckdb/storage/statistics/numeric_stats.hpp>
 
 #include <graphar/api/arrow_reader.h>
 #include <graphar/api/high_level_reader.h>
@@ -29,9 +30,12 @@
 #include <graphar/graph_info.h>
 #include <graphar/reader_util.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
+#include <mini-yaml/yaml/Yaml.hpp>
 #include <sstream>
+#include <unordered_map>
 #include <variant>
 
 namespace duckdb {
@@ -133,6 +137,13 @@ class ReadBase;
 class ReadVertices;
 class ReadEdges;
 
+struct ColumnStats {
+    bool has_min_max = false;
+    std::string min_val;
+    std::string max_val;
+    bool is_nullable = true;
+};
+
 class ReadBindData : public TableFunctionData {
 public:
     ReadBindData() = default;
@@ -140,6 +151,7 @@ public:
     vector<std::string>& GetFlattenPropNames() { return flatten_prop_names; }
     vector<std::string>& GetFlattenPropTypes() { return flatten_prop_types; }
     const std::shared_ptr<graphar::GraphInfo>& GetGraphInfo() const { return graph_info; }
+    std::unordered_map<std::string, ColumnStats>& GetStatsMap() { return stats_map; }
 
 private:
     vector<vector<std::string>> prop_names;
@@ -157,6 +169,7 @@ private:
     std::string filter_column;
 
     TypeInfoPtr type_info;
+    std::unordered_map<std::string, ColumnStats> stats_map;
 
     template <typename ReadFinal>
     friend class ReadBase;
@@ -272,6 +285,81 @@ public:
         }
 
         bind_data->graph_info = graph_info;
+
+        // 1. Evaluate Nullability for all collected columns
+        for (const auto& col_name : bind_data->flatten_prop_names) {
+            ColumnStats c_stats;
+            // ID columns are never null
+            if (std::find(id_columns.begin(), id_columns.end(), col_name) != id_columns.end()) {
+                c_stats.is_nullable = false;
+            } else {
+                if (std::holds_alternative<std::shared_ptr<graphar::VertexInfo>>(type_info)) {
+                    auto v_info = std::get<std::shared_ptr<graphar::VertexInfo>>(type_info);
+                    c_stats.is_nullable = v_info->IsNullableKey(col_name);
+                } else if (std::holds_alternative<std::shared_ptr<graphar::EdgeInfo>>(type_info)) {
+                    auto e_info = std::get<std::shared_ptr<graphar::EdgeInfo>>(type_info);
+                    c_stats.is_nullable = e_info->IsNullableKey(col_name);
+                }
+            }
+            bind_data->stats_map[col_name] = c_stats;
+        }
+
+        // 2. Parse YAML from Extra Info for statistics (Min/Max values)
+        const auto& extra_info = graph_info->GetExtraInfo();
+        if (extra_info.find("statistics") != extra_info.end()) {
+            std::string table_name_key;
+            if (bind_data->params.size() == 1) {
+                table_name_key = bind_data->params[0];  // Vertex: Label
+            } else if (bind_data->params.size() == 3) {
+                table_name_key = bind_data->params[0] + "_" + bind_data->params[1] + "_" +
+                                 bind_data->params[2];  // Edge: src_edge_dst
+            }
+
+            try {
+                Yaml::Node root;
+                Yaml::Parse(root, extra_info.at("statistics"));
+
+                for (auto table_it = root.Begin(); table_it != root.End(); table_it++) {
+                    auto& table_node = (*table_it).second;
+
+                    for (auto map_it = table_node.Begin(); map_it != table_node.End(); map_it++) {
+                        std::string table_name = (*map_it).first;
+
+                        if (table_name == table_name_key) {
+                            auto& columns_node = (*map_it).second;
+                            for (auto column_it = columns_node.Begin(); column_it != columns_node.End(); column_it++) {
+                                std::string column_name = (*column_it).first;
+
+                                if (bind_data->stats_map.find(column_name) != bind_data->stats_map.end()) {
+                                    auto& column_node = (*column_it).second;
+                                    bool has_min = false, has_max = false;
+                                    std::string min_val, max_val;
+
+                                    for (auto stat_it = column_node.Begin(); stat_it != column_node.End(); stat_it++) {
+                                        if ((*stat_it).first == "min") {
+                                            min_val = (*stat_it).second.As<std::string>();
+                                            has_min = true;
+                                        } else if ((*stat_it).first == "max") {
+                                            max_val = (*stat_it).second.As<std::string>();
+                                            has_max = true;
+                                        }
+                                    }
+
+                                    if (has_min && has_max) {
+                                        bind_data->stats_map[column_name].has_min_max = true;
+                                        bind_data->stats_map[column_name].min_val = min_val;
+                                        bind_data->stats_map[column_name].max_val = max_val;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (const std::exception& e) {
+                DUCKDB_GRAPHAR_LOG_DEBUG("Failed to parse YAML statistics: " + std::string(e.what()));
+            }
+        }
+
         DUCKDB_GRAPHAR_LOG_TRACE("ReadBase::SetBindData finished");
     }
 
@@ -298,6 +386,67 @@ public:
 
     static const vector<std::pair<graphar::IdType, graphar::IdType>>& GetVidRanges(const ReadBindData& bind_data) {
         return bind_data.vid_ranges;
+    }
+    
+    static unique_ptr<BaseStatistics> GetStatistics(ClientContext& context, const FunctionData* bind_data,
+                                                    column_t column_index) {
+        DUCKDB_GRAPHAR_LOG_TRACE("ReadBase::GetStatistics");
+        auto read_bind_data = bind_data->Cast<ReadBindData>();
+        if (column_index < 0 || column_index >= read_bind_data.GetFlattenPropTypes().size()) {
+            return nullptr;
+        }
+
+        auto duck_type = GraphArFunctions::graphArT2duckT(read_bind_data.GetFlattenPropTypes()[column_index]);
+        auto column_name = read_bind_data.GetFlattenPropNames()[column_index];
+
+        auto& stats_map = read_bind_data.GetStatsMap();
+        if (stats_map.find(column_name) == stats_map.end()) {
+            return BaseStatistics::CreateUnknown(duck_type).ToUnique();
+        }
+
+        auto& c_stats = stats_map[column_name];
+        auto stats = BaseStatistics::CreateUnknown(duck_type);
+
+        // 1. Initialize stats object and apply Min/Max values if available
+        if (c_stats.has_min_max && LogicalType::IsNumeric(duck_type)) {
+            stats = NumericStats::CreateEmpty(duck_type);
+            switch (duck_type) {
+                case LogicalTypeId::TINYINT:
+                    NumericStats::SetMin<int8_t>(stats, static_cast<int8_t>(std::stoi(c_stats.min_val)));
+                    NumericStats::SetMax<int8_t>(stats, static_cast<int8_t>(std::stoi(c_stats.max_val)));
+                    break;
+                case LogicalTypeId::SMALLINT:
+                    NumericStats::SetMin<int16_t>(stats, static_cast<int16_t>(std::stoi(c_stats.min_val)));
+                    NumericStats::SetMax<int16_t>(stats, static_cast<int16_t>(std::stoi(c_stats.max_val)));
+                    break;
+                case LogicalTypeId::INTEGER:
+                    NumericStats::SetMin<int32_t>(stats, static_cast<int32_t>(std::stoll(c_stats.min_val)));
+                    NumericStats::SetMax<int32_t>(stats, static_cast<int32_t>(std::stoll(c_stats.max_val)));
+                    break;
+                case LogicalTypeId::BIGINT:
+                    NumericStats::SetMin<int64_t>(stats, static_cast<int64_t>(std::stoll(c_stats.min_val)));
+                    NumericStats::SetMax<int64_t>(stats, static_cast<int64_t>(std::stoll(c_stats.max_val)));
+                    break;
+                case LogicalTypeId::FLOAT:
+                    NumericStats::SetMin<float>(stats, std::stof(c_stats.min_val));
+                    NumericStats::SetMax<float>(stats, std::stof(c_stats.max_val));
+                    break;
+                case LogicalTypeId::DOUBLE:
+                    NumericStats::SetMin<double>(stats, std::stod(c_stats.min_val));
+                    NumericStats::SetMax<double>(stats, std::stod(c_stats.max_val));
+                    break;
+                default:
+                    stats = BaseStatistics::CreateUnknown(duck_type);
+                    break;
+            }
+        }
+
+        // 2. Apply explicit nullability marker
+        if (!c_stats.is_nullable) {
+            stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+        }
+
+        return stats.ToUnique();
     }
 
     static unique_ptr<GlobalTableFunctionState> Init(ClientContext& context, TableFunctionInitInput& input) {

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -238,12 +238,22 @@ private:
         return true;
     }
 
-    static bool IsValidFloat(const std::string& s) {
+    template <typename T>
+    static bool TryParseFiniteFloatingPoint(const std::string& s, T& out) {
         if (s.empty()) return false;
+
         const char* start = s.c_str();
         char* end = nullptr;
-        double val = std::strtod(start, &end);
-        return (end != start && *end == '\0' && std::isfinite(val));
+
+        if constexpr (std::is_same_v<T, float>) {
+            out = std::strtof(start, &end);
+        } else if constexpr (std::is_same_v<T, double>) {
+            out = std::strtod(start, &end);
+        } else {
+            static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>);
+        }
+
+        return end != start && *end == '\0' && std::isfinite(out);
     }
 
     template <typename T>
@@ -263,10 +273,15 @@ private:
     template <typename T>
     static bool ValidateAndConvertFloatStats(const std::string& min_str, const std::string& max_str, Value& out_min,
                                              Value& out_max, Value (*creator)(T)) {
-        if (!IsValidFloat(min_str) || !IsValidFloat(max_str)) return false;
-        T min_val = static_cast<T>(std::stod(min_str));
-        T max_val = static_cast<T>(std::stod(max_str));
+        T min_val;
+        T max_val;
+
+        if (!TryParseFiniteFloatingPoint(min_str, min_val) || !TryParseFiniteFloatingPoint(max_str, max_val)) {
+            return false;
+        }
+
         if (min_val > max_val) return false;
+
         out_min = creator(min_val);
         out_max = creator(max_val);
         return true;

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -210,15 +210,7 @@ ReaderPtr ReadEdges::GetReader(ClientContext& context, ReadBaseGlobalTableFuncti
 //-------------------------------------------------------------------
 unique_ptr<BaseStatistics> ReadEdges::GetStatistics(ClientContext& context, const FunctionData* bind_data,
                                                     column_t column_index) {
-    DUCKDB_GRAPHAR_LOG_TRACE("ReadEdges::GetStatistics");
-    auto read_bind_data = bind_data->Cast<ReadBindData>();
-    if (column_index < 0 || column_index >= read_bind_data.GetFlattenPropTypes().size()) {
-        return nullptr;
-    }
-    auto duck_type = GraphArFunctions::graphArT2duckT(read_bind_data.GetFlattenPropTypes()[column_index]);
-    auto column_name = read_bind_data.GetFlattenPropNames()[column_index];
-    auto stats = BaseStatistics::CreateUnknown(duck_type);
-    return stats.ToUnique();
+    return ReadBase<ReadEdges>::GetStatistics(context, bind_data, column_index);
 }
 //-------------------------------------------------------------------
 // PushdownComplexFilter

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -154,15 +154,7 @@ ReaderPtr ReadVertices::GetReader(ClientContext& context, ReadBaseGlobalTableFun
 //-------------------------------------------------------------------
 unique_ptr<BaseStatistics> ReadVertices::GetStatistics(ClientContext& context, const FunctionData* bind_data,
                                                        column_t column_index) {
-    DUCKDB_GRAPHAR_LOG_TRACE("ReadVertices::GetStatistics");
-    auto read_bind_data = bind_data->Cast<ReadBindData>();
-    if (column_index < 0 || column_index >= read_bind_data.GetFlattenPropTypes().size()) {
-        return nullptr;
-    }
-    auto duck_type = GraphArFunctions::graphArT2duckT(read_bind_data.GetFlattenPropTypes()[column_index]);
-    auto column_name = read_bind_data.GetFlattenPropNames()[column_index];
-    auto stats = BaseStatistics::CreateUnknown(duck_type);
-    return stats.ToUnique();
+    return ReadBase<ReadVertices>::GetStatistics(context, bind_data, column_index);
 }
 //-------------------------------------------------------------------
 // PushdownComplexFilter

--- a/tests/table_functions/CMakeLists.txt
+++ b/tests/table_functions/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library_unity(test_table_functions OBJECT test_read_vertices.cpp test_read_e
 add_dependencies(test_table_functions graphar)
 target_include_directories(test_table_functions PRIVATE
     ${GRAPHAR_INSTALL_DIR}/include
+    ${GRAPHAR_SOURCE_DIR}/graphar/cpp/thirdparty
     ${ARROW_INSTALL_DIR}/include
     ${EXTENSION_ROOT_DIR}/include
     ${CATCH2_INCLUDE_DIRS}

--- a/tests/table_functions/test_read_edges.cpp
+++ b/tests/table_functions/test_read_edges.cpp
@@ -128,20 +128,26 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges GetStatistics test",
     INFO("Finish bind test");
 
     INFO("GetStatistics test");
-    // Test that GetStatistics returns valid statistics for each column
+    auto& read_bind_data = bind_data->Cast<ReadBindData>();
+    
     for (column_t col_idx = 0; col_idx < return_types.size(); col_idx++) {
         unique_ptr<BaseStatistics> stats;
         REQUIRE_NOTHROW(stats = read_edges.statistics(*TestFixture::conn.context, bind_data.get(), col_idx));
         REQUIRE(stats != nullptr);
         
-        // Check that the statistics type matches the column type
         REQUIRE(stats->GetType() == return_types[col_idx]);
         
-        // For BIGINT columns (src, dst), check that we have numeric stats
         if (return_types[col_idx].id() == LogicalTypeId::BIGINT) {
-            // Statistics should be created even without extra_info
-            // The type should match
             REQUIRE(stats->GetType().id() == LogicalTypeId::BIGINT);
+        }
+        
+        auto column_name = read_bind_data.GetFlattenPropNames()[col_idx];
+        auto& stats_map = read_bind_data.GetStatsMap();
+        REQUIRE(stats_map.find(column_name) != stats_map.end());
+        
+        auto& col_stats = stats_map.at(column_name);
+        if (column_name == SRC_GID_COLUMN || column_name == DST_GID_COLUMN) {
+            REQUIRE(!col_stats.is_nullable);
         }
     }
     INFO("Finish GetStatistics test");

--- a/tests/table_functions/test_read_edges.cpp
+++ b/tests/table_functions/test_read_edges.cpp
@@ -107,6 +107,46 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges Bind and Execute fun
     REQUIRE(res.ColumnCount() == 2);
     INFO("Finish execute test");
 }
+
+TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges GetStatistics test", "[read_edges]", FILE_TYPES_FOR_TEST) {
+    INFO("Start mocking");
+    vector<Value> inputs({Value(TestFixture::path_trial_graph)});
+    named_parameter_map_t named_parameters({{"src", Value("Person")}, {"dst", Value("Person")}, {"type", Value("knows")}});
+    vector<LogicalType> input_table_types({});
+    auto input = TestFixture::CreateMockBindInput(inputs, named_parameters, input_table_types);
+    
+    vector<LogicalType> return_types;
+    vector<std::string> names;
+    INFO("Finish mocking");
+
+    TableFunction read_edges = ReadEdges::GetFunction();
+
+    INFO("Bind test");
+    unique_ptr<FunctionData> bind_data;
+    REQUIRE_NOTHROW(bind_data = read_edges.bind(*TestFixture::conn.context, input, return_types, names));
+    REQUIRE(bind_data != nullptr);
+    INFO("Finish bind test");
+
+    INFO("GetStatistics test");
+    // Test that GetStatistics returns valid statistics for each column
+    for (column_t col_idx = 0; col_idx < return_types.size(); col_idx++) {
+        unique_ptr<BaseStatistics> stats;
+        REQUIRE_NOTHROW(stats = read_edges.statistics(*TestFixture::conn.context, bind_data.get(), col_idx));
+        REQUIRE(stats != nullptr);
+        
+        // Check that the statistics type matches the column type
+        REQUIRE(stats->GetType() == return_types[col_idx]);
+        
+        // For BIGINT columns (src, dst), check that we have numeric stats
+        if (return_types[col_idx].id() == LogicalTypeId::BIGINT) {
+            // Statistics should be created even without extra_info
+            // The type should match
+            REQUIRE(stats->GetType().id() == LogicalTypeId::BIGINT);
+        }
+    }
+    INFO("Finish GetStatistics test");
+}
+
 /* // Uncomment after fixing SIGSEGV
 TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges Bind and Execute functions edge with property", "[read_edges]", FILE_TYPES_FOR_TEST) {
     INFO("Start mocking");

--- a/tests/table_functions/test_read_vertices.cpp
+++ b/tests/table_functions/test_read_vertices.cpp
@@ -119,20 +119,27 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadVertices GetStatistics tes
     INFO("Finish bind test");
 
     INFO("GetStatistics test");
-    // Test that GetStatistics returns valid statistics for each column
+    auto& read_bind_data = bind_data->Cast<ReadBindData>();
+    
     for (column_t col_idx = 0; col_idx < return_types.size(); col_idx++) {
         unique_ptr<BaseStatistics> stats;
         REQUIRE_NOTHROW(stats = read_vertices.statistics(*TestFixture::conn.context, bind_data.get(), col_idx));
         REQUIRE(stats != nullptr);
         
-        // Check that the statistics type matches the column type
         REQUIRE(stats->GetType() == return_types[col_idx]);
         
-        // For numeric columns, verify we have appropriate statistics
         if (return_types[col_idx].id() == LogicalTypeId::BIGINT || 
             return_types[col_idx].id() == LogicalTypeId::INTEGER) {
-            // Statistics should be created even without extra_info
             REQUIRE(stats->GetType().id() == return_types[col_idx].id());
+        }
+        
+        auto column_name = read_bind_data.GetFlattenPropNames()[col_idx];
+        auto& stats_map = read_bind_data.GetStatsMap();
+        REQUIRE(stats_map.find(column_name) != stats_map.end());
+        
+        auto& col_stats = stats_map.at(column_name);
+        if (column_name == GID_COLUMN_INTERNAL) {
+            REQUIRE(!col_stats.is_nullable);
         }
     }
     INFO("Finish GetStatistics test");

--- a/tests/table_functions/test_read_vertices.cpp
+++ b/tests/table_functions/test_read_vertices.cpp
@@ -99,6 +99,45 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadVertices Bind function inv
     REQUIRE_THROWS_AS(read_vertices.bind(*TestFixture::conn.context, input, return_types, names), BinderException);
 }
 
+TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadVertices GetStatistics test", "[read_vertices]", FILE_TYPES_FOR_TEST) {
+    INFO("Start mocking");
+    vector<Value> inputs({Value(TestFixture::path_trial_graph)});
+    named_parameter_map_t named_parameters({{"type", Value("Person")}});
+    vector<LogicalType> input_table_types({});
+    auto input = TestFixture::CreateMockBindInput(inputs, named_parameters, input_table_types);
+
+    vector<LogicalType> return_types;
+    vector<std::string> names;
+    INFO("Finish mocking");
+    
+    TableFunction read_vertices = ReadVertices::GetFunction();
+
+    INFO("Bind test");
+    unique_ptr<FunctionData> bind_data;
+    REQUIRE_NOTHROW(bind_data = read_vertices.bind(*TestFixture::conn.context, input, return_types, names));
+    REQUIRE(bind_data != nullptr);
+    INFO("Finish bind test");
+
+    INFO("GetStatistics test");
+    // Test that GetStatistics returns valid statistics for each column
+    for (column_t col_idx = 0; col_idx < return_types.size(); col_idx++) {
+        unique_ptr<BaseStatistics> stats;
+        REQUIRE_NOTHROW(stats = read_vertices.statistics(*TestFixture::conn.context, bind_data.get(), col_idx));
+        REQUIRE(stats != nullptr);
+        
+        // Check that the statistics type matches the column type
+        REQUIRE(stats->GetType() == return_types[col_idx]);
+        
+        // For numeric columns, verify we have appropriate statistics
+        if (return_types[col_idx].id() == LogicalTypeId::BIGINT || 
+            return_types[col_idx].id() == LogicalTypeId::INTEGER) {
+            // Statistics should be created even without extra_info
+            REQUIRE(stats->GetType().id() == return_types[col_idx].id());
+        }
+    }
+    INFO("Finish GetStatistics test");
+}
+
 /* // Uncomment after fixing SIGSEGV
 TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture,"ReadVertices Bind and Execute functions vertex with properties", "[read_vertices]", FILE_TYPES_FOR_TEST) {
     INFO("Start mocking");


### PR DESCRIPTION
- Fix GraphAr source/include paths in CMake and test targets.
- Parse column nullability and YAML min/max stats from GraphAr extra info during bind.
- Reuse shared ReadBase::GetStatistics for vertices and edges to expose numeric statistics for optimizer/filter pushdown.