### PR TITLE
feat(hop): Add two hop univeral function: hop2

### DIFF
--- a/.github/workflows/static-pipeline.yml
+++ b/.github/workflows/static-pipeline.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           git submodule update --init --remote duckdb
           cd duckdb
+          git fetch origin
           git fetch --tags origin
           cd ..
           DUCKDB_GIT_VERSION=$(cat .github/duckdb_version) make set_duckdb_version

--- a/.github/workflows/static-pipeline.yml
+++ b/.github/workflows/static-pipeline.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Set up DuckDB
         id: duckdb-version
         run: |
-          git submodule update --init --remote duckdb
+          git submodule update --init duckdb
           cd duckdb
           git fetch origin
           git fetch --tags origin

--- a/config/test/sql/graphar/hop.test
+++ b/config/test/sql/graphar/hop.test
@@ -1,0 +1,36 @@
+require duckdb_graphar
+
+statement ok
+SET autoinstall_known_extensions=1;
+
+statement ok
+SET autoload_known_extensions=1;
+
+query I
+SELECT COUNT(*) FROM hop2('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
+----
+17457
+
+query I
+SELECT COUNT(*) FROM hop2('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
+----
+18247
+
+
+statement ok
+ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
+
+query I
+SELECT COUNT(*) FROM hop2('Person_knows_Person', vid=10);
+----
+17457
+
+query I
+SELECT COUNT(*) FROM hop2('Person_knows_Person', vids=[1, 10]);
+----
+18247
+
+query I
+SELECT COUNT(*) FROM hop2('Person_knows_Person', vids=[1, 10]) WHERE _graphArDstIndex != 2370;
+----
+18209

--- a/include/functions/table/hop.hpp
+++ b/include/functions/table/hop.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "functions/table/hop_base.hpp"
+#include "functions/table/read_base.hpp"
+
+#include <duckdb/common/named_parameter_map.hpp>
+#include <duckdb/function/table/arrow/arrow_duck_schema.hpp>
+#include <duckdb/function/table_function.hpp>
+#include <duckdb/main/extension/extension_loader.hpp>
+
+#include <graphar/api/high_level_reader.h>
+#include <graphar/arrow/chunk_reader.h>
+#include <graphar/graph_info.h>
+
+#include <cassert>
+#include <cxxabi.h>
+
+namespace duckdb {
+
+class HopBindData : public HopBaseBindData {
+    std::string query_filter;
+    std::string graph_info_path;
+
+    friend class Hop;
+};
+
+class HopGlobalTableFunctionState : public GlobalTableFunctionState {
+private:
+    std::string query;
+    std::unique_ptr<duckdb::Connection> conn;
+    unique_ptr<QueryResult> result;
+
+    friend class Hop;
+};
+
+class Hop : public ReadBase<ReadHop> {
+public:
+    static unique_ptr<FunctionData> Bind(ClientContext& context, TableFunctionBindInput& input,
+                                         vector<LogicalType>& return_types, vector<string>& names);
+    static unique_ptr<GlobalTableFunctionState> Init(ClientContext& context, TableFunctionInitInput& input);
+    static void Execute(ClientContext& context, TableFunctionInput& input, DataChunk& output);
+    static void PushdownComplexFilter(ClientContext& context, LogicalGet& get, FunctionData* bind_data,
+                                      vector<unique_ptr<Expression>>& filters);
+
+    static string WhichFunction(HopBindData& bind_data, TableFunctionInitInput& input);
+
+    static TableFunctionSet GetFunctions();
+    static void SetTableFuncionParams(TableFunction& fun) {
+        fun.init_global = Init;
+
+        HopBase::SetFunctionParams(fun);
+
+        fun.filter_pushdown = false;
+        fun.projection_pushdown = true;
+        fun.pushdown_complex_filter = PushdownComplexFilter;
+    }
+    static void Register(ExtensionLoader& loader) { loader.RegisterFunction(GetFunctions()); }
+
+    static std::string GetFunctionName() { return "hop2"; }
+};
+}  // namespace duckdb

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -218,6 +218,7 @@ class ReadEdges;
 class HopBase;
 class ReadHop;
 class ReadHopFiltered;
+class Hop;
 
 class HopBaseGlobalTableFunctionState;
 class ReadHopGlobalTableFunctionState;
@@ -265,6 +266,7 @@ private:
     friend class HopBase;
     friend class ReadHop;
     friend class ReadHopFiltered;
+    friend class Hop;
 };
 
 class ReadBaseGlobalTableFunctionState : public GlobalTableFunctionState {

--- a/include/functions/table/two_hop.hpp
+++ b/include/functions/table/two_hop.hpp
@@ -56,13 +56,6 @@ class TwoHop {
 public:
     static unique_ptr<FunctionData> Bind(ClientContext& context, TableFunctionBindInput& input,
                                          vector<LogicalType>& return_types, vector<string>& names);
-    static unique_ptr<FunctionData> BindEdgeTable(ClientContext& context, TableFunctionBindInput& input,
-                                                  vector<LogicalType>& return_types, vector<string>& names);
-    static unique_ptr<FunctionData> BindGraphInfoPath(ClientContext& context, TableFunctionBindInput& input,
-                                                      vector<LogicalType>& return_types, vector<string>& names);
-    static unique_ptr<FunctionData> BindFinish(ClientContext& context, TableFunctionBindInput& input,
-                                               vector<LogicalType>& return_types, vector<string>& names,
-                                               unique_ptr<TwoHopBindData> bind_data);
     static unique_ptr<GlobalTableFunctionState> Init(ClientContext& context, TableFunctionInitInput& input);
     static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext& context, TableFunctionInitInput& input,
                                                          GlobalTableFunctionState* gstate_ptr);

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -26,6 +26,9 @@ public:
 
     void SetVertex(graphar::IdType _vid) {
         DUCKDB_GRAPHAR_LOG_TRACE("LowEdgeReaderByVertex::SetVertex " + std::to_string(_vid));
+        if (_vid < 0) {
+            throw IOException("LowEdgeReaderByVertex: _vid = " + std::to_string(_vid) + " < 0");
+        }
         vid = _vid;
         offset = offset_reader->GetOffset(vid);
         vertex_chunk_index = vid / offset_reader->vertex_chunk_size;
@@ -36,6 +39,9 @@ public:
         DUCKDB_GRAPHAR_LOG_TRACE("LowEdgeReaderByVertex::read");
         if (!started()) {
             start();
+        }
+        if (!started()) {
+            return nullptr;
         }
         return std::move(result->Fetch());
     }
@@ -48,6 +54,11 @@ public:
             throw InternalException("LowEdgeReaderByVertex::start: conn is nullptr");
         }
         auto paths = GetChunkPaths();
+        if (paths.empty()) {
+            result = nullptr;
+            return;
+        }
+
         vector<Value> paths_val;
         paths_val.reserve(paths.size());
         for (auto& el : paths) {

--- a/src/duckdb_graphar_extension.cpp
+++ b/src/duckdb_graphar_extension.cpp
@@ -4,6 +4,7 @@
 
 #include "functions/table/edges_vertex.hpp"
 #include "functions/table/graphar_info.hpp"
+#include "functions/table/hop.hpp"
 #include "functions/table/read_edges.hpp"
 #include "functions/table/read_hop.hpp"
 #include "functions/table/read_hop_filtered.hpp"
@@ -58,6 +59,7 @@ static void LoadInternal(ExtensionLoader& loader) {
     TwoHop::Register(loader);
     ReadHop::Register(loader);
     ReadHopFiltered::Register(loader);
+    Hop::Register(loader);
     GraphArInfo::Register(loader);
     ShortestPath::Register(loader);
 

--- a/src/functions/table/hop.cpp
+++ b/src/functions/table/hop.cpp
@@ -1,0 +1,189 @@
+#include "functions/table/hop.hpp"
+
+#include "functions/table/hop_base.hpp"
+#include "storage/graphar_catalog.hpp"
+#include "storage/graphar_schema_entry.hpp"
+#include "utils/benchmark.hpp"
+#include "utils/func.hpp"
+#include "utils/global_log_manager.hpp"
+
+#include <duckdb/common/named_parameter_map.hpp>
+#include <duckdb/common/vector_size.hpp>
+#include <duckdb/function/table/arrow.hpp>
+#include <duckdb/function/table_function.hpp>
+
+#include <graphar/api/high_level_reader.h>
+#include <graphar/graph_info.h>
+
+#include <iostream>
+
+namespace duckdb {
+//-------------------------------------------------------------------
+// Bind
+//-------------------------------------------------------------------
+unique_ptr<FunctionData> Hop::Bind(ClientContext& context, TableFunctionBindInput& input,
+                                   vector<LogicalType>& return_types, vector<string>& names) {
+    DUCKDB_GRAPHAR_LOG_TRACE("Hop::Bind");
+    const bool is_catalog_mode = HopBase::IsCatalogMode(input);
+
+    auto bind_data = make_uniq<HopBindData>();
+
+    if (is_catalog_mode) {
+        HopBase::SetBindDataByEdgeTable(context, input, *bind_data);
+    } else {
+        HopBase::SetBindDataByGraphPath(context, input, *bind_data);
+        bind_data->graph_info_path = StringValue::Get(input.inputs[0]);
+    }
+
+    HopBase::SetBindDataVids(input, *bind_data);
+
+    auto graph_info = bind_data->graph_info;
+    auto edge_info = bind_data->edge_info;
+    unique_ptr<ReadBindData> base_bind_data = std::move(bind_data);
+    ReadBase::SetBindData(graph_info, edge_info, base_bind_data, GetFunctionName(), 0, 1,
+                          {SRC_GID_COLUMN, DST_GID_COLUMN});
+    bind_data.reset(static_cast<HopBindData*>(base_bind_data.release()));
+
+    names = bind_data->GetFlattenPropNames();
+    const auto& fpt = bind_data->GetFlattenPropTypes();
+    std::transform(fpt.begin(), fpt.end(), std::back_inserter(return_types),
+                   [](const auto& return_type) { return GraphArFunctions::graphArT2duckT(return_type); });
+
+    HopBase::SetBindDataDstIdx(names, *bind_data);
+
+    return std::move(bind_data);
+}
+//-------------------------------------------------------------------
+// PushdownComplexFilter
+//-------------------------------------------------------------------
+void Hop::PushdownComplexFilter(ClientContext& context, LogicalGet& get, FunctionData* bind_data,
+                                vector<unique_ptr<Expression>>& filters) {
+    DUCKDB_GRAPHAR_LOG_TRACE("Hop::PushdownComplexFilter");
+    if (!bind_data) {
+        throw InternalException("Bind data is nullptr");
+    }
+    auto& hop_bind_data = bind_data->Cast<HopBindData>();
+    for (size_t i = 0; i < filters.size(); ++i) {
+        if (i) hop_bind_data.query_filter += " AND ";
+        hop_bind_data.query_filter += filters[i]->ToString();
+    }
+    DUCKDB_GRAPHAR_LOG_DEBUG("Hop::filters<" + std::to_string(filters.size()) + ">:" + hop_bind_data.query_filter);
+
+    vector<unique_ptr<Expression>> filters_new;
+    filters = std::move(filters_new);
+}
+//-------------------------------------------------------------------
+// WhichFunction
+//-------------------------------------------------------------------
+string Hop::WhichFunction(HopBindData& bind_data, TableFunctionInitInput& input) {
+    DUCKDB_GRAPHAR_LOG_TRACE("Hop::WhichFunction");
+
+    bool need_filters = !bind_data.query_filter.empty();
+
+    if (need_filters) {
+        return "read_hop_filtered";
+    }
+
+    bool only_src_dst = true;
+    const auto& columns = bind_data.GetFlattenPropNames();
+    for (auto& column_id : input.column_ids) {
+        if (columns[column_id] != SRC_GID_COLUMN && columns[column_id] != DST_GID_COLUMN) {
+            only_src_dst = false;
+            break;
+        }
+    }
+
+    if (only_src_dst) {
+        return "two_hop";
+    }
+    return "read_hop";
+}
+//-------------------------------------------------------------------
+// Init
+//-------------------------------------------------------------------
+unique_ptr<GlobalTableFunctionState> Hop::Init(ClientContext& context, TableFunctionInitInput& input) {
+    DUCKDB_GRAPHAR_LOG_TRACE("Hop::Init");
+
+    auto bind_data = input.bind_data->Cast<HopBindData>();
+
+    auto gstate_ptr = make_uniq<HopGlobalTableFunctionState>();
+    auto& gstate = *gstate_ptr;
+
+    const auto& columns = bind_data.GetFlattenPropNames();
+    for (auto& column_id : input.column_ids) {
+        if (gstate.query.empty()) {
+            gstate.query += "SELECT " + columns[column_id];
+        } else {
+            gstate.query += ", " + columns[column_id];
+        }
+    }
+    gstate.query += " FROM ";
+    gstate.query += WhichFunction(bind_data, input);
+    gstate.query += "(";
+
+    if (bind_data.table_name.empty()) {
+        gstate.query += "'";
+        gstate.query += bind_data.graph_info_path;
+        gstate.query += "', src='";
+        gstate.query += bind_data.GetSrcName();
+        gstate.query += "', dst='";
+        gstate.query += bind_data.GetDstName();
+        gstate.query += ", type='";
+        gstate.query += bind_data.edge_info->GetEdgeType();
+        gstate.query += "'";
+    } else {
+        gstate.query += "'";
+        gstate.query += bind_data.table_name;
+        gstate.query += "'";
+        if (!bind_data.catalog_name.empty()) {
+            gstate.query += ", catalog='";
+            gstate.query += bind_data.catalog_name;
+            gstate.query += "'";
+        }
+    }
+
+    gstate.query += ", vids=[";
+    for (auto& vid : bind_data.vids) {
+        gstate.query += std::to_string(vid) + ",";
+    }
+    gstate.query.pop_back();
+    gstate.query += "]";
+    gstate.query += ")";
+
+    if (!bind_data.query_filter.empty()) {
+        gstate.query += " WHERE " + bind_data.query_filter;
+    }
+    gstate.query += ";";
+
+    gstate.conn = make_uniq<duckdb::Connection>(*context.db);
+    DUCKDB_GRAPHAR_LOG_WARN("Hop::Query = " + gstate.query);
+    gstate.result = gstate.conn->Query(gstate.query);
+
+    return gstate_ptr;
+}
+//-------------------------------------------------------------------
+// Execute
+//-------------------------------------------------------------------
+void Hop::Execute(ClientContext& context, TableFunctionInput& input, DataChunk& output) {
+    DUCKDB_GRAPHAR_LOG_TRACE("Hop::Execute");
+    auto& gstate = input.global_state->Cast<HopGlobalTableFunctionState>();
+    std::unique_ptr<DataChunk> data = std::move(gstate.result->Fetch());
+    if (data) {
+        output.Reference(*data);
+    } else {
+        output.SetCardinality(0);
+    }
+}
+//-------------------------------------------------------------------
+// GetFunction
+//-------------------------------------------------------------------
+TableFunctionSet Hop::GetFunctions() {
+    TableFunctionSet hop(GetFunctionName());
+
+    TableFunction hop_default({LogicalType::VARCHAR}, Execute, Bind);
+    SetTableFuncionParams(hop_default);
+    hop.AddFunction(hop_default);
+
+    return hop;
+}
+}  // namespace duckdb

--- a/src/functions/table/hop.cpp
+++ b/src/functions/table/hop.cpp
@@ -125,10 +125,10 @@ unique_ptr<GlobalTableFunctionState> Hop::Init(ClientContext& context, TableFunc
         gstate.query += "'";
         gstate.query += bind_data.graph_info_path;
         gstate.query += "', src='";
-        gstate.query += bind_data.GetSrcName();
+        gstate.query += bind_data.edge_info->GetSrcType();
         gstate.query += "', dst='";
-        gstate.query += bind_data.GetDstName();
-        gstate.query += ", type='";
+        gstate.query += bind_data.edge_info->GetDstType();
+        gstate.query += "', type='";
         gstate.query += bind_data.edge_info->GetEdgeType();
         gstate.query += "'";
     } else {
@@ -156,7 +156,7 @@ unique_ptr<GlobalTableFunctionState> Hop::Init(ClientContext& context, TableFunc
     gstate.query += ";";
 
     gstate.conn = make_uniq<duckdb::Connection>(*context.db);
-    DUCKDB_GRAPHAR_LOG_WARN("Hop::Query = " + gstate.query);
+    DUCKDB_GRAPHAR_LOG_DEBUG("Hop::Query = " + gstate.query);
     gstate.result = gstate.conn->Query(gstate.query);
 
     return gstate_ptr;


### PR DESCRIPTION
Added a new universal table function hop2 that dynamically selects the optimal execution method based on query requirements.

Features
Graph topology only (src/dst indices) -> calls two_hop()
Edge properties -> calls read_hop() 
With filtering -> calls read_hop_filtered()