### PR TITLE
fix(hops): bump DuckDB to v1.6.0 and fix few hops bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,8 @@ set(DISABLE_VPTR_SANITIZER ON CACHE BOOL "")
 FetchContent_Declare(
     duckdb
     GIT_REPOSITORY https://github.com/duckdb/duckdb.git
-    GIT_TAG v1.5.1
-    GIT_SHALLOW TRUE
+    GIT_TAG 86cc0b4b980afa845d6ad90910e0ee869e019509
+    GIT_SHALLOW FALSE
     GIT_PROGRESS TRUE
 )
 log_done()

--- a/config/test/sql/graphar/attach.test
+++ b/config/test/sql/graphar/attach.test
@@ -2,7 +2,7 @@ require duckdb_graphar
 
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT name from (SHOW ALL TABLES) ORDER BY name;

--- a/config/test/sql/graphar/batch_onehop.test
+++ b/config/test/sql/graphar/batch_onehop.test
@@ -7,7 +7,7 @@ statement ok
 SET autoload_known_extensions=1;
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT id FROM 'Person' WHERE _graphArVertexIndex IN [5, 5];

--- a/config/test/sql/graphar/batch_onehop.test
+++ b/config/test/sql/graphar/batch_onehop.test
@@ -7,6 +7,9 @@ statement ok
 SET autoload_known_extensions=1;
 
 statement ok
+LOAD parquet;
+
+statement ok
 ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I

--- a/config/test/sql/graphar/read_edges.test
+++ b/config/test/sql/graphar/read_edges.test
@@ -7,23 +7,23 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person');
+SELECT COUNT(*) FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person');
 ----
 289003
 
 query I
-SELECT COUNT(*) FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=1;
+SELECT COUNT(*) FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=1;
 ----
 8
 
 query II
-SELECT * FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=0;
+SELECT * FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=0;
 ----
 0
 23977
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT _graphArDstIndex FROM 'Person_knows_Person' LIMIT 1;

--- a/config/test/sql/graphar/read_edges.test
+++ b/config/test/sql/graphar/read_edges.test
@@ -6,6 +6,9 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
+statement ok
+LOAD parquet;
+
 query I
 SELECT COUNT(*) FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person');
 ----

--- a/config/test/sql/graphar/read_edges_csv.test
+++ b/config/test/sql/graphar/read_edges_csv.test
@@ -7,23 +7,23 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person');
+SELECT COUNT(*) FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person');
 ----
 289003
 
 query I
-SELECT COUNT(*) FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=1;
+SELECT COUNT(*) FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=1;
 ----
 8
 
 query II
-SELECT * FROM read_edges('__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=0;
+SELECT * FROM read_edges('{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person') WHERE _graphArSrcIndex=0;
 ----
 0
 23977
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT _graphArDstIndex FROM 'Person_knows_Person' LIMIT 1;

--- a/config/test/sql/graphar/read_hop.test
+++ b/config/test/sql/graphar/read_hop.test
@@ -7,18 +7,18 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_hop('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
+SELECT COUNT(*) FROM read_hop('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
 ----
 17457
 
 query I
-SELECT COUNT(*) FROM read_hop('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
+SELECT COUNT(*) FROM read_hop('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
 ----
 18247
 
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
 
 query I
 SELECT COUNT(*) FROM read_hop('Person_knows_Person', vid=10);

--- a/config/test/sql/graphar/read_hop.test
+++ b/config/test/sql/graphar/read_hop.test
@@ -6,6 +6,9 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
+statement ok
+LOAD parquet;
+
 query I
 SELECT COUNT(*) FROM read_hop('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
 ----

--- a/config/test/sql/graphar/read_hop_filtered.test
+++ b/config/test/sql/graphar/read_hop_filtered.test
@@ -6,6 +6,9 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
+statement ok
+LOAD parquet;
+
 query I
 SELECT COUNT(*) FROM read_hop_filtered('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
 ----

--- a/config/test/sql/graphar/read_hop_filtered.test
+++ b/config/test/sql/graphar/read_hop_filtered.test
@@ -7,18 +7,18 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_hop_filtered('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
+SELECT COUNT(*) FROM read_hop_filtered('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
 ----
 17457
 
 query I
-SELECT COUNT(*) FROM read_hop_filtered('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
+SELECT COUNT(*) FROM read_hop_filtered('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
 ----
 18247
 
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
 
 query I
 SELECT COUNT(*) FROM read_hop_filtered('Person_knows_Person', vid=10);

--- a/config/test/sql/graphar/read_vertices.test
+++ b/config/test/sql/graphar/read_vertices.test
@@ -7,12 +7,12 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_vertices('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', type='Person');
+SELECT COUNT(*) FROM read_vertices('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', type='Person');
 ----
 37700
 
 query IIIIII
-SELECT * FROM read_vertices('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', type='Person') WHERE _grapharVertexIndex=0;
+SELECT * FROM read_vertices('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', type='Person') WHERE _grapharVertexIndex=0;
 ----
 0
 0
@@ -22,7 +22,7 @@ false
 0
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT id FROM 'Person' LIMIT 4;

--- a/config/test/sql/graphar/read_vertices.test
+++ b/config/test/sql/graphar/read_vertices.test
@@ -6,6 +6,9 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
+statement ok
+LOAD parquet;
+
 query I
 SELECT COUNT(*) FROM read_vertices('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', type='Person');
 ----

--- a/config/test/sql/graphar/read_vertices_csv.test
+++ b/config/test/sql/graphar/read_vertices_csv.test
@@ -7,12 +7,12 @@ statement ok
 SET autoload_known_extensions=1;
 
 query I
-SELECT COUNT(*) FROM read_vertices('__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml', type='Person');
+SELECT COUNT(*) FROM read_vertices('{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml', type='Person');
 ----
 37700
 
 query IIIIII
-SELECT * FROM read_vertices('__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml', type='Person') WHERE _grapharVertexIndex=0;
+SELECT * FROM read_vertices('{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml', type='Person') WHERE _grapharVertexIndex=0;
 ----
 0
 0
@@ -22,7 +22,7 @@ false
 0
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github-csv/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github-csv/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 query I
 SELECT id FROM 'Person' LIMIT 4;

--- a/config/test/sql/graphar/shortest_path.test
+++ b/config/test/sql/graphar/shortest_path.test
@@ -7,7 +7,7 @@ statement ok
 SET autoload_known_extensions=1;
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as test_db (type duckdb_graphar);
 
 ################################################################################
 # Test 1: Direct edge (1-hop path)
@@ -131,7 +131,7 @@ SELECT COUNT(*) AS path_length,
        MIN(_graphArVertexIndex) FILTER (WHERE step_number = 0) AS first_vertex,
        MIN(_graphArVertexIndex) FILTER (WHERE _graphArVertexIndex = 23977) AS end_vertex
 FROM shortest_path(0, 23977,
-    '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml',
+    '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml',
     src='Person', type='knows', dst='Person');
 ----
 2	0	23977
@@ -141,7 +141,7 @@ FROM shortest_path(0, 23977,
 ################################################################################
 query II
 SELECT * FROM shortest_path(5, 5,
-    '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml',
+    '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml',
     src='Person', type='knows', dst='Person');
 ----
 0	5
@@ -151,7 +151,7 @@ SELECT * FROM shortest_path(5, 5,
 ################################################################################
 query II
 SELECT * FROM shortest_path(37699, 0,
-    '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml',
+    '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml',
     src='Person', type='knows', dst='Person');
 ----
 
@@ -160,7 +160,7 @@ SELECT * FROM shortest_path(37699, 0,
 ################################################################################
 statement error
 SELECT * FROM shortest_path(0, 5,
-    '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml',
+    '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml',
     src='Person', type='nonexistent', dst='Person');
 ----
 Binder Error: Edges of this type are not found: Person_nonexistent_Person

--- a/config/test/sql/graphar/two_hop.test
+++ b/config/test/sql/graphar/two_hop.test
@@ -6,19 +6,22 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
+statement ok
+LOAD parquet;
+
 query I
-SELECT COUNT(*) FROM two_hop('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
+SELECT COUNT(*) FROM two_hop('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vid=10);
 ----
 17457
 
 query I
-SELECT COUNT(*) FROM two_hop('__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
+SELECT COUNT(*) FROM two_hop('{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml', src='Person', type='knows', dst='Person', vids=[1, 10]);
 ----
 18247
 
 
 statement ok
-ATTACH '__WORKING_DIRECTORY__/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
+ATTACH '{WORKING_DIRECTORY}/../data/snap-musae-github/graphar/Git.graph.yaml' as git(type duckdb_graphar);
 
 query I
 SELECT COUNT(*) FROM two_hop('Person_knows_Person', vid=10);

--- a/include/functions/table/hop_base.hpp
+++ b/include/functions/table/hop_base.hpp
@@ -131,17 +131,17 @@ public:
         if (catalog_entry != input.named_parameters.end()) {
             catalog_name = StringValue::Get(catalog_entry->second);
         }
-        auto& catalog = Catalog::GetCatalog(context, catalog_name);
+        auto& catalog = Catalog::GetCatalog(context, Identifier(bind_data.catalog_name));
         if (catalog.GetCatalogType() != GraphArCatalog::TYPE) {
             throw BinderException("Expecting a GraphAr catalog, but got %s", catalog.GetCatalogType());
         }
-        bind_data.catalog_name = catalog.GetName();
+        bind_data.catalog_name = catalog.GetName().GetIdentifierName();
 
-        auto& graphar_catalog = catalog.Cast<GraphArCatalog>();
+        auto& graphar_catalog = catalog.template Cast<GraphArCatalog>();
         bind_data.graph_info = graphar_catalog.GetGraphInfo();
 
         auto& schema = graphar_catalog.GetMainSchema();
-        bind_data.schema_name = schema.Name;
+        bind_data.schema_name = schema.name.GetIdentifierName();
 
         auto& tables = schema.tables;
         auto table_info = tables.GetTableInfo(context, schema, bind_data.table_name);

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -17,6 +17,7 @@
 #include <duckdb/main/extension/extension_loader.hpp>
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/execution/expression_executor.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
@@ -847,7 +848,6 @@ public:
             }
         }
 
-        output.SetCapacity(num_rows);
         output.SetCardinality(num_rows);
         gstate.total_rows += num_rows;
         DUCKDB_GRAPHAR_LOG_DEBUG("Size of chunk: " + std::to_string(num_rows) +
@@ -888,18 +888,21 @@ public:
             bool can_pushdown = false;
 
             // Case 0: equality comparison (col = value)
-            if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-                auto& comparison = filter->Cast<BoundComparisonExpression>();
-                if (comparison.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
-                    bool left_is_scalar = comparison.left->IsFoldable();
-                    bool right_is_scalar = comparison.right->IsFoldable();
+            if (filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION &&
+                BoundComparisonExpression::IsComparison(*filter)) {
+                auto& comp_expr = filter->Cast<BoundFunctionExpression>();
+                if (comp_expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL) {
+                    auto& left = BoundComparisonExpression::Left(comp_expr);
+                    auto& right = BoundComparisonExpression::Right(comp_expr);
+                    bool left_is_scalar = left.IsFoldable();
+                    bool right_is_scalar = right.IsFoldable();
                     if (left_is_scalar || right_is_scalar) {
-                        auto column_name = comparison.left->ToString();
+                        auto column_name = left.ToString();
                         Value val;
 
-                        auto& scalar_expr = (comparison.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)
-                                                ? *comparison.right
-                                                : *comparison.left;
+                        auto& scalar_expr = (left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)
+                                                ? right
+                                                : left;
 
                         if (!ExpressionExecutor::TryEvaluateScalar(context, scalar_expr, val)) {
                             continue;
@@ -916,14 +919,14 @@ public:
             // Case 1: list_contains([1, 2, 3], col) -- list literal
             if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
                 auto& op_expr = filter->Cast<BoundFunctionExpression>();
-                const auto& fname = op_expr.function.name;
+                const auto& fname = op_expr.Function().GetName().GetIdentifierName();
                 if (fname == "contains" || fname == "list_contains" || fname == "array_contains" ||
                     fname == "list_has" || fname == "array_has") {
-                    if (op_expr.children.size() == 2 &&
-                        op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                        auto& const_expr = op_expr.children[0]->Cast<BoundConstantExpression>();
-                        auto column_name = op_expr.children[1]->ToString();
-                        auto& list_value = const_expr.value;
+                    if (op_expr.GetChildrenMutable().size() == 2 &&
+                        op_expr.GetChildrenMutable()[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                        auto& const_expr = op_expr.GetChildrenMutable()[0]->Cast<BoundConstantExpression>();
+                        auto column_name = op_expr.GetChildrenMutable()[1]->ToString();
+                        auto& list_value = const_expr.GetValue();
 
                         if (list_value.type().id() == LogicalTypeId::LIST) {
                             auto list_children = ListValue::GetChildren(list_value);
@@ -944,12 +947,12 @@ public:
             if (!can_pushdown && filter->GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
                 filter->GetExpressionType() == ExpressionType::COMPARE_IN) {
                 auto& op_expr = filter->Cast<BoundOperatorExpression>();
-                if (op_expr.children[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-                    auto column_name = op_expr.children[0]->ToString();
+                if (op_expr.GetChildrenMutable()[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+                    auto column_name = op_expr.GetChildrenMutable()[0]->ToString();
                     bool any = false;
-                    for (idx_t i = 1; i < op_expr.children.size(); i++) {
-                        if (op_expr.children[i]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                            auto& cv = op_expr.children[i]->Cast<BoundConstantExpression>().value;
+                    for (idx_t i = 1; i < op_expr.GetChildrenMutable().size(); i++) {
+                        if (op_expr.GetChildrenMutable()[i]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                            auto& cv = op_expr.GetChildrenMutable()[i]->Cast<BoundConstantExpression>().GetValue();
                             if (validate_wrapper(column_name, cv)) any = true;
                         }
                     }
@@ -969,23 +972,26 @@ public:
                 std::vector<Value> local_vals;
                 bool valid = true;
 
-                for (auto& child : conj.children) {
-                    if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON ||
+                for (auto& child : conj.GetChildrenMutable()) {
+                    if (child->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION ||
+                        !BoundComparisonExpression::IsComparison(*child) ||
                         child->GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
                         valid = false;
                         break;
                     }
-                    auto& cmp = child->Cast<BoundComparisonExpression>();
+                    auto& comp_expr = child->Cast<BoundFunctionExpression>();
                     std::string col;
                     Value val;
-                    if (cmp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
-                        cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                        col = cmp.left->ToString();
-                        val = cmp.right->Cast<BoundConstantExpression>().value;
-                    } else if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
-                               cmp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
-                        col = cmp.right->ToString();
-                        val = cmp.left->Cast<BoundConstantExpression>().value;
+                    auto& left = BoundComparisonExpression::Left(comp_expr);
+                    auto& right = BoundComparisonExpression::Right(comp_expr);
+                    if (left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+                        right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                        col = left.ToString();
+                        val = right.Cast<BoundConstantExpression>().GetValue();
+                    } else if (right.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+                               left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+                        col = right.ToString();
+                        val = left.Cast<BoundConstantExpression>().GetValue();
                     } else {
                         valid = false;
                         break;

--- a/include/functions/table/read_base.hpp
+++ b/include/functions/table/read_base.hpp
@@ -12,12 +12,12 @@
 #include <arrow/c/bridge.h>
 
 #include <duckdb/common/named_parameter_map.hpp>
+#include <duckdb/execution/expression_executor.hpp>
 #include <duckdb/function/table/arrow.hpp>
 #include <duckdb/function/table_function.hpp>
 #include <duckdb/main/extension/extension_loader.hpp>
 #include <duckdb/planner/expression.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
-#include <duckdb/execution/expression_executor.hpp>
 #include <duckdb/planner/expression/bound_conjunction_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
 #include <duckdb/planner/expression/bound_function_expression.hpp>
@@ -900,9 +900,8 @@ public:
                         auto column_name = left.ToString();
                         Value val;
 
-                        auto& scalar_expr = (left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF)
-                                                ? right
-                                                : left;
+                        auto& scalar_expr =
+                            (left.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) ? right : left;
 
                         if (!ExpressionExecutor::TryEvaluateScalar(context, scalar_expr, val)) {
                             continue;

--- a/include/functions/table/two_hop.hpp
+++ b/include/functions/table/two_hop.hpp
@@ -37,12 +37,21 @@ public:
         DUCKDB_GRAPHAR_LOG_TRACE("TwoHopLocalTableFunctionState::MoveReader");
         std::lock_guard<std::mutex> lock(gstate.lock);
 
+        DUCKDB_GRAPHAR_LOG_DEBUG(
+            "TwoHopLocalTableFunctionState::MoveReader - vertexes size=" + std::to_string(gstate.vertexes.size()) +
+            " cur_idx=" + std::to_string(cur_idx) + " gstate.cur_idx=" + std::to_string(gstate.cur_idx) +
+            " next_hop_idx=" + std::to_string(gstate.next_hop_idx));
+
         if (!gstate.vertexes.empty()) {
             cur_idx = gstate.cur_idx++;
-            reader->SetVertex(gstate.vertexes.front());
+            auto vid = gstate.vertexes.front();
+            DUCKDB_GRAPHAR_LOG_DEBUG("TwoHopLocalTableFunctionState::MoveReader - processing vid=" +
+                                     std::to_string(vid));
+            reader->SetVertex(vid);
             gstate.vertexes.pop();
             in_progress = true;
         } else {
+            DUCKDB_GRAPHAR_LOG_DEBUG("TwoHopLocalTableFunctionState::MoveReader - no more vertexes, finishing");
             in_progress = false;
         }
     }

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -20,7 +20,9 @@ public:
           adj_list_type(adj_list_type),
           file_type(edge_info->GetAdjacentList(adj_list_type)->GetFileType()),
           vid(-1),
-          vertex_chunk_index(-1) {
+          vertex_chunk_index(-1),
+          cached_vertex_chunk_index(-1),
+          cached_edge_chunk_num(0) {
         DUCKDB_GRAPHAR_LOG_TRACE("LowEdgeReaderByVertex::LowEdgeReaderByVertex");
         offset_reader = std::make_unique<OffsetReader>(edge_info, prefix, adj_list_type);
         duckdb_prefix = prefix;
@@ -60,16 +62,29 @@ public:
             throw InternalException("LowEdgeReaderByVertex::start: conn is nullptr");
         }
 
-        auto maybe_edge_chunk_num =
-            graphar::util::GetEdgeChunkNum(original_prefix, edge_info, adj_list_type, vertex_chunk_index);
+        if (vertex_chunk_index != cached_vertex_chunk_index) {
+            auto maybe_edge_chunk_num =
+                graphar::util::GetEdgeChunkNum(original_prefix, edge_info, adj_list_type, vertex_chunk_index);
 
-        if (!maybe_edge_chunk_num.has_value() || maybe_edge_chunk_num.value() <= 0) {
-            DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
+            if (!maybe_edge_chunk_num.has_value() || maybe_edge_chunk_num.value() <= 0) {
+                DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
+                cached_edge_chunk_num = 0;
+                cached_vertex_chunk_index = vertex_chunk_index;
+                result = nullptr;
+                return;
+            }
+
+            cached_edge_chunk_num = maybe_edge_chunk_num.value();
+            cached_vertex_chunk_index = vertex_chunk_index;
+        }
+
+        graphar::IdType edge_chunk_num = cached_edge_chunk_num;
+        if (edge_chunk_num <= 0) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks to read for vertex " + std::to_string(vid));
             result = nullptr;
             return;
         }
 
-        graphar::IdType edge_chunk_num = maybe_edge_chunk_num.value();
         DUCKDB_GRAPHAR_LOG_DEBUG("Edge chunk num for vertex chunk " + std::to_string(vertex_chunk_index) + ": " +
                                  std::to_string(edge_chunk_num));
 
@@ -169,5 +184,7 @@ private:
     std::unique_ptr<OffsetReader> offset_reader;
     graphar::IdType vid;
     std::string duckdb_prefix;
+    graphar::IdType cached_vertex_chunk_index;
+    graphar::IdType cached_edge_chunk_num;
 };
 }  // namespace duckdb

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -7,6 +7,7 @@
 #include <duckdb/main/query_result.hpp>
 
 #include <graphar/api/info.h>
+#include <graphar/reader_util.h>
 
 namespace duckdb {
 
@@ -15,13 +16,17 @@ public:
     LowEdgeReaderByVertex(const std::shared_ptr<graphar::EdgeInfo> edge_info, const std::string& prefix,
                           graphar::AdjListType adj_list_type)
         : edge_info(edge_info),
-          prefix(prefix),
+          original_prefix(prefix),
           adj_list_type(adj_list_type),
           file_type(edge_info->GetAdjacentList(adj_list_type)->GetFileType()),
           vid(-1),
           vertex_chunk_index(-1) {
         DUCKDB_GRAPHAR_LOG_TRACE("LowEdgeReaderByVertex::LowEdgeReaderByVertex");
         offset_reader = std::make_unique<OffsetReader>(edge_info, prefix, adj_list_type);
+        duckdb_prefix = prefix;
+        if (!duckdb_prefix.empty() && duckdb_prefix.back() != '/') {
+            duckdb_prefix += '/';
+        }
     }
 
     void SetVertex(graphar::IdType _vid) {
@@ -29,6 +34,9 @@ public:
         vid = _vid;
         offset = offset_reader->GetOffset(vid);
         vertex_chunk_index = vid / offset_reader->vertex_chunk_size;
+        DUCKDB_GRAPHAR_LOG_DEBUG("LowEdgeReaderByVertex::SetVertex - vid=" + std::to_string(vid) + " offset=[" +
+                                 std::to_string(offset.first) + "," + std::to_string(offset.second) + ")" +
+                                 " vertex_chunk_index=" + std::to_string(vertex_chunk_index));
         result = nullptr;
     }
 
@@ -36,6 +44,10 @@ public:
         DUCKDB_GRAPHAR_LOG_TRACE("LowEdgeReaderByVertex::read");
         if (!started()) {
             start();
+        }
+        if (result == nullptr) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("LowEdgeReaderByVertex::read - returning empty chunk (no files)");
+            return nullptr;
         }
         return std::move(result->Fetch());
     }
@@ -47,31 +59,75 @@ public:
         if (!conn) {
             throw InternalException("LowEdgeReaderByVertex::start: conn is nullptr");
         }
-        auto paths = GetChunkPaths();
-        vector<Value> paths_val;
-        paths_val.reserve(paths.size());
-        for (auto& el : paths) {
-            paths_val.emplace_back(prefix + el);
+
+        auto maybe_edge_chunk_num =
+            graphar::util::GetEdgeChunkNum(original_prefix, edge_info, adj_list_type, vertex_chunk_index);
+
+        if (!maybe_edge_chunk_num.has_value() || maybe_edge_chunk_num.value() <= 0) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
+            result = nullptr;
+            return;
         }
+
+        graphar::IdType edge_chunk_num = maybe_edge_chunk_num.value();
+        DUCKDB_GRAPHAR_LOG_DEBUG("Edge chunk num for vertex chunk " + std::to_string(vertex_chunk_index) + ": " +
+                                 std::to_string(edge_chunk_num));
+
+        auto chunk_range = GetChunkRange();
+        auto begin_chunk = chunk_range.first;
+        auto end_chunk = chunk_range.second;
+
+        if (begin_chunk >= edge_chunk_num || begin_chunk >= end_chunk) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("No chunks to read for vertex " + std::to_string(vid));
+            result = nullptr;
+            return;
+        }
+
+        if (end_chunk > edge_chunk_num) {
+            end_chunk = edge_chunk_num;
+        }
+
+        vector<Value> paths_val;
+        paths_val.reserve(end_chunk - begin_chunk);
+
+        for (int chunk_index = begin_chunk; chunk_index < end_chunk; ++chunk_index) {
+            auto path = edge_info->GetAdjListFilePath(vertex_chunk_index, chunk_index, adj_list_type).value();
+            std::string full_path = duckdb_prefix + path;
+            paths_val.emplace_back(full_path);
+        }
+
+        if (paths_val.empty()) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("No chunk files to read for vertex " + std::to_string(vid));
+            result = nullptr;
+            return;
+        }
+
         std::string query = GetQuery();
         auto offset_in_chunk = offset.first % edge_info->GetChunkSize();
         auto count = offset.second - offset.first;
         Value path_list_val = Value::LIST(paths_val);
-        DUCKDB_GRAPHAR_LOG_DEBUG("LowEdgeReaderByVertex::params: " + path_list_val.ToString() + " " +
-                                 std::to_string(offset_in_chunk) + " " + std::to_string(count));
+        DUCKDB_GRAPHAR_LOG_DEBUG("Executing query with " + std::to_string(paths_val.size()) + " files");
         result = std::move(conn->Query(query, path_list_val, offset_in_chunk, count));
+
+        if (result && result->HasError()) {
+            DUCKDB_GRAPHAR_LOG_DEBUG("Query error: " + result->GetError());
+            result = nullptr;
+        }
     }
 
     std::vector<std::string> GetChunkPaths() {
         auto range = GetChunkRange();
         auto begin_chunk = range.first, end_chunk = range.second;
-        std::vector<std::string> chunks(end_chunk - begin_chunk);
-        for (int chunk_index = begin_chunk; chunk_index < end_chunk; ++chunk_index) {
-            chunks[chunk_index - begin_chunk] =
-                edge_info->GetAdjListFilePath(vertex_chunk_index, chunk_index, adj_list_type).value();
+        std::vector<std::string> chunks;
+        if (begin_chunk >= end_chunk) {
+            return chunks;
         }
-
-        return std::move(chunks);
+        chunks.reserve(end_chunk - begin_chunk);
+        for (int chunk_index = begin_chunk; chunk_index < end_chunk; ++chunk_index) {
+            auto path = edge_info->GetAdjListFilePath(vertex_chunk_index, chunk_index, adj_list_type).value();
+            chunks.push_back(path);
+        }
+        return chunks;
     }
 
     std::pair<graphar::IdType, graphar::IdType> GetChunkRange() {
@@ -105,12 +161,13 @@ public:
 
 private:
     const std::shared_ptr<graphar::EdgeInfo> edge_info;
-    const std::string prefix;
+    const std::string original_prefix;
     graphar::AdjListType adj_list_type;
     graphar::FileType file_type;
     graphar::IdType vertex_chunk_index;
     std::unique_ptr<QueryResult> result = nullptr;
     std::unique_ptr<OffsetReader> offset_reader;
     graphar::IdType vid;
+    std::string duckdb_prefix;
 };
 }  // namespace duckdb

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -73,7 +73,7 @@ public:
                 result = nullptr;
                 return;
             }
-            
+
             if (maybe_edge_chunk_num.value() <= 0) {
                 DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
                 cached_edge_chunk_num = 0;

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -66,7 +66,15 @@ public:
             auto maybe_edge_chunk_num =
                 graphar::util::GetEdgeChunkNum(original_prefix, edge_info, adj_list_type, vertex_chunk_index);
 
-            if (!maybe_edge_chunk_num.has_value() || maybe_edge_chunk_num.value() <= 0) {
+            if (!maybe_edge_chunk_num.has_value()) {
+                DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
+                cached_edge_chunk_num = 0;
+                cached_vertex_chunk_index = vertex_chunk_index;
+                result = nullptr;
+                return;
+            }
+            
+            if (maybe_edge_chunk_num.value() <= 0) {
                 DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
                 cached_edge_chunk_num = 0;
                 cached_vertex_chunk_index = vertex_chunk_index;
@@ -120,8 +128,8 @@ public:
         std::string query = GetQuery();
         auto offset_in_chunk = offset.first % edge_info->GetChunkSize();
         auto count = offset.second - offset.first;
-        Value path_list_val = Value::LIST(paths_val);
         DUCKDB_GRAPHAR_LOG_DEBUG("Executing query with " + std::to_string(paths_val.size()) + " files");
+        Value path_list_val = Value::LIST(paths_val);
         result = std::move(conn->Query(query, path_list_val, offset_in_chunk, count));
 
         if (result && result->HasError()) {

--- a/include/readers/low_edge_reader.hpp
+++ b/include/readers/low_edge_reader.hpp
@@ -66,15 +66,7 @@ public:
             auto maybe_edge_chunk_num =
                 graphar::util::GetEdgeChunkNum(original_prefix, edge_info, adj_list_type, vertex_chunk_index);
 
-            if (!maybe_edge_chunk_num.has_value()) {
-                DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
-                cached_edge_chunk_num = 0;
-                cached_vertex_chunk_index = vertex_chunk_index;
-                result = nullptr;
-                return;
-            }
-
-            if (maybe_edge_chunk_num.value() <= 0) {
+            if (!maybe_edge_chunk_num.has_value() || maybe_edge_chunk_num.value() <= 0) {
                 DUCKDB_GRAPHAR_LOG_DEBUG("No edge chunks found for vertex chunk " + std::to_string(vertex_chunk_index));
                 cached_edge_chunk_num = 0;
                 cached_vertex_chunk_index = vertex_chunk_index;

--- a/include/storage/graphar_catalog.hpp
+++ b/include/storage/graphar_catalog.hpp
@@ -19,7 +19,7 @@ class GraphArCatalog : public Catalog {
 public:
     explicit GraphArCatalog(AttachedDatabase& db_p, const std::string& path_,
                             std::shared_ptr<graphar::GraphInfo>& graph_info_, ClientContext& context,
-                            std::string& database_name);
+                            const std::string& database_name);
     ~GraphArCatalog();
     static inline const string TYPE = "graphar";
 

--- a/include/utils/global_log_manager.hpp
+++ b/include/utils/global_log_manager.hpp
@@ -4,22 +4,20 @@
 #include <duckdb/logging/logging.hpp>
 #include <duckdb/main/database.hpp>
 
-#include <optional>
-
 namespace duckdb {
 class GlobalLogManager {
 public:
     static void Initialize(DatabaseInstance& db, LogLevel log_level = LogLevel::LOG_INFO);
 
     static LogManager& GetLogManager() {
-        if (!log_manager.has_value()) {
+        if (!log_manager) {
             throw InternalException("LogManager is not initialized");
         }
-        return log_manager.value();
+        return *log_manager;
     }
 
 private:
-    static std::optional<std::reference_wrapper<LogManager>> log_manager;
+    static LogManager* log_manager;
 };
 };  // namespace duckdb
 

--- a/src/duckdb_graphar_extension.cpp
+++ b/src/duckdb_graphar_extension.cpp
@@ -38,19 +38,20 @@ static void FinalizeS3(DataChunk& args, ExpressionState& state, Vector& result) 
 }
 
 static void LoadInternal(ExtensionLoader& loader) {
+    auto& config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+
+    config.AddExtensionOption("graphar_time_logging", "Enable time logging for GraphAr requests.", LogicalType::BOOLEAN,
+                              Value::BOOLEAN(false));
+
+    // Initialize GlobalLogManager before using any logging macros
+    GlobalLogManager::Initialize(loader.GetDatabaseInstance(), duckdb::LogLevel::LOG_WARNING);
+
     auto duckdb_graphar_scalar_function =
         ScalarFunction("duckdb_graphar", {LogicalType::VARCHAR}, LogicalType::VARCHAR, QuackScalarFun);
     loader.RegisterFunction(duckdb_graphar_scalar_function);
 
     auto finalize_s3_function = ScalarFunction("duckdb_graphar_finalize_s3", {}, LogicalType::VARCHAR, FinalizeS3);
     loader.RegisterFunction(finalize_s3_function);
-
-    auto& config = DBConfig::GetConfig(loader.GetDatabaseInstance());
-
-    config.AddExtensionOption("graphar_time_logging", "Enable time logging for GraphAr requests.", LogicalType::BOOLEAN,
-                              Value::BOOLEAN(false));
-
-    GlobalLogManager::Initialize(loader.GetDatabaseInstance(), duckdb::LogLevel::LOG_WARNING);
 
     ReadVertices::Register(loader);
     ReadEdges::Register(loader);

--- a/src/functions/table/edges_vertex.cpp
+++ b/src/functions/table/edges_vertex.cpp
@@ -8,10 +8,10 @@
 #include <duckdb/common/named_parameter_map.hpp>
 #include <duckdb/common/vector_size.hpp>
 #include <duckdb/function/table_function.hpp>
-#include <duckdb/planner/table_filter_set.hpp>
-#include <duckdb/planner/filter/expression_filter.hpp>
 #include <duckdb/planner/expression/bound_comparison_expression.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
 
 #include <graphar/api/high_level_reader.h>
 #include <graphar/graph_info.h>
@@ -104,31 +104,31 @@ unique_ptr<GlobalTableFunctionState> EdgesVertexGlobalTableFunctionState::Init(C
         auto filter_id = filter_entry.GetIndex();
         auto filter_index = input.column_ids[filter_id];
         auto& filter = filter_entry.Filter();
-        
+
         // Check if it's an expression filter
         if (filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
             throw NotImplementedException("Only expression filters are supported");
         }
-        
+
         auto& expr_filter = ExpressionFilter::GetExpressionFilter(filter, "EdgesVertex");
         auto& expr = expr_filter.expr;
-        
+
         // Check if it's a comparison expression
         if (!BoundComparisonExpression::IsComparison(*expr)) {
             throw NotImplementedException("Only comparison filters are supported");
         }
-        
+
         auto& comparison = expr->Cast<BoundFunctionExpression>();
         if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
             throw NotImplementedException("Only equality filters are supported");
         }
-        
+
         // Get the right side (constant value)
         auto& right = BoundComparisonExpression::Right(comparison);
         if (right.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
             throw NotImplementedException("Only constant value comparisons are supported");
         }
-        
+
         auto& constant_expr = right.Cast<BoundConstantExpression>();
         auto filter_value = constant_expr.GetValue().ToString();
 

--- a/src/functions/table/edges_vertex.cpp
+++ b/src/functions/table/edges_vertex.cpp
@@ -8,6 +8,10 @@
 #include <duckdb/common/named_parameter_map.hpp>
 #include <duckdb/common/vector_size.hpp>
 #include <duckdb/function/table_function.hpp>
+#include <duckdb/planner/table_filter_set.hpp>
+#include <duckdb/planner/filter/expression_filter.hpp>
+#include <duckdb/planner/expression/bound_comparison_expression.hpp>
+#include <duckdb/planner/expression/bound_constant_expression.hpp>
 
 #include <graphar/api/high_level_reader.h>
 #include <graphar/graph_info.h>
@@ -93,21 +97,40 @@ unique_ptr<GlobalTableFunctionState> EdgesVertexGlobalTableFunctionState::Init(C
     if (input.filters) {
         DUCKDB_GRAPHAR_LOG_DEBUG("Found filters");
 
-        if (input.filters->filters.size() > 1) {
+        if (input.filters->FilterCount() > 1) {
             throw NotImplementedException("Multiple filters are not supported");
         }
-        auto filter_id = input.filters->filters.begin()->first;
+        auto& filter_entry = *input.filters->begin();
+        auto filter_id = filter_entry.GetIndex();
         auto filter_index = input.column_ids[filter_id];
-        auto& filter = input.filters->filters.begin()->second;
-        if (filter->filter_type != TableFilterType::CONSTANT_COMPARISON) {
-            throw NotImplementedException("Only constant filters are supported, but got " + filter->ToString(" "));
+        auto& filter = filter_entry.Filter();
+        
+        // Check if it's an expression filter
+        if (filter.filter_type != TableFilterType::EXPRESSION_FILTER) {
+            throw NotImplementedException("Only expression filters are supported");
         }
-        auto filter_expr = filter->ToString(" ");
-        if (filter_expr[1] != '=') {
+        
+        auto& expr_filter = ExpressionFilter::GetExpressionFilter(filter, "EdgesVertex");
+        auto& expr = expr_filter.expr;
+        
+        // Check if it's a comparison expression
+        if (!BoundComparisonExpression::IsComparison(*expr)) {
+            throw NotImplementedException("Only comparison filters are supported");
+        }
+        
+        auto& comparison = expr->Cast<BoundFunctionExpression>();
+        if (comparison.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
             throw NotImplementedException("Only equality filters are supported");
         }
-
-        auto filter_value = filter_expr.substr(2);
+        
+        // Get the right side (constant value)
+        auto& right = BoundComparisonExpression::Right(comparison);
+        if (right.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+            throw NotImplementedException("Only constant value comparisons are supported");
+        }
+        
+        auto& constant_expr = right.Cast<BoundConstantExpression>();
+        auto filter_value = constant_expr.GetValue().ToString();
 
         if (filter_index + 1 == input.column_ids.size()) {
             DUCKDB_GRAPHAR_LOG_DEBUG("Filter by gid");
@@ -226,10 +249,8 @@ inline void EdgesVertex::Execute(ClientContext& context, TableFunctionInput& inp
         output.SetValue(1, i, static_cast<int64_t>(gstate.GetIter()));
     }
     if (end <= start) {
-        output.SetCapacity(0);
         output.SetCardinality(0);
     } else {
-        output.SetCapacity(end - start);
         output.SetCardinality(end - start);
     }
 

--- a/src/functions/table/read_edges.cpp
+++ b/src/functions/table/read_edges.cpp
@@ -265,7 +265,7 @@ static void InitFunction(TableFunction& read_edges) {
 // GetFunction
 //-------------------------------------------------------------------
 TableFunction ReadEdges::GetFunction() {
-    TableFunction read_edges(GetFunctionName(), {LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction read_edges(Identifier(GetFunctionName()), {LogicalType::VARCHAR}, Execute, Bind);
     InitFunction(read_edges);
 
     read_edges.named_parameters["src"] = LogicalType::VARCHAR;
@@ -278,7 +278,7 @@ TableFunction ReadEdges::GetFunction() {
 // GetScanFunction
 //-------------------------------------------------------------------
 TableFunction ReadEdges::GetScanFunction() {
-    TableFunction read_edges({}, Execute, Bind);
+    TableFunction read_edges("", {LogicalType::VARCHAR}, Execute, Bind);
     InitFunction(read_edges);
 
     return read_edges;

--- a/src/functions/table/read_hop.cpp
+++ b/src/functions/table/read_hop.cpp
@@ -87,9 +87,9 @@ ReaderPtr ReadHop::GetReader(ClientContext& context, ReadBaseGlobalTableFunction
 // GetFunction
 //-------------------------------------------------------------------
 TableFunctionSet ReadHop::GetFunctions() {
-    TableFunctionSet read_hop(GetFunctionName());
+    TableFunctionSet read_hop((Identifier(GetFunctionName())));
 
-    TableFunction read_hop_default({LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction read_hop_default("", {LogicalType::VARCHAR}, Execute, Bind);
     SetTableFuncionParams(read_hop_default);
     read_hop.AddFunction(read_hop_default);
 
@@ -99,7 +99,7 @@ TableFunctionSet ReadHop::GetFunctions() {
 // GetScanFunction
 //-------------------------------------------------------------------
 TableFunction ReadHop::GetScanFunction() {
-    TableFunction read_hop(GetFunctionName(), {}, Execute, Bind);
+    TableFunction read_hop("", {}, Execute, Bind);
     SetTableFuncionParams(read_hop);
     return read_hop;
 }
@@ -254,7 +254,7 @@ void ReadHop::Execute(ClientContext& context, TableFunctionInput& input, DataChu
         }
     }
 
-    output.SetCapacity(num_rows);
+    output.SetChildCardinality(num_rows);
     output.SetCardinality(num_rows);
     gstate.total_rows += num_rows;
     gstate.chunk_count++;

--- a/src/functions/table/read_hop_filtered.cpp
+++ b/src/functions/table/read_hop_filtered.cpp
@@ -108,9 +108,9 @@ void ReadHopFiltered::PushdownComplexFilter(ClientContext& context, LogicalGet& 
 // GetFunction
 //-------------------------------------------------------------------
 TableFunctionSet ReadHopFiltered::GetFunctions() {
-    TableFunctionSet read_hop_filtered(GetFunctionName());
+    TableFunctionSet read_hop_filtered((Identifier(GetFunctionName())));
 
-    TableFunction read_hop_defalt({LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction read_hop_defalt("", {LogicalType::VARCHAR}, Execute, Bind);
 
     SetTableFuncionParams(read_hop_defalt);
     read_hop_filtered.AddFunction(read_hop_defalt);
@@ -121,7 +121,7 @@ TableFunctionSet ReadHopFiltered::GetFunctions() {
 // GetScanFunction
 //-------------------------------------------------------------------
 TableFunction ReadHopFiltered::GetScanFunction() {
-    TableFunction read_hop(GetFunctionName(), {}, Execute, Bind);
+    TableFunction read_hop("", {}, Execute, Bind);
     SetTableFuncionParams(read_hop);
 
     return read_hop;
@@ -386,7 +386,7 @@ void ReadHopFiltered::Execute(ClientContext& context, TableFunctionInput& input,
         }
     }
 
-    output.SetCapacity(num_rows);
+    output.SetChildCardinality(num_rows);
     output.SetCardinality(num_rows);
     gstate.total_rows += num_rows;
     gstate.chunk_count++;

--- a/src/functions/table/read_hop_filtered.cpp
+++ b/src/functions/table/read_hop_filtered.cpp
@@ -110,10 +110,10 @@ void ReadHopFiltered::PushdownComplexFilter(ClientContext& context, LogicalGet& 
 TableFunctionSet ReadHopFiltered::GetFunctions() {
     TableFunctionSet read_hop_filtered((Identifier(GetFunctionName())));
 
-    TableFunction read_hop_defalt("", {LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction read_hop_default("", {LogicalType::VARCHAR}, Execute, Bind);
 
-    SetTableFuncionParams(read_hop_defalt);
-    read_hop_filtered.AddFunction(read_hop_defalt);
+    SetTableFuncionParams(read_hop_default);
+    read_hop_filtered.AddFunction(read_hop_default);
 
     return read_hop_filtered;
 }

--- a/src/functions/table/read_vertices.cpp
+++ b/src/functions/table/read_vertices.cpp
@@ -198,7 +198,7 @@ static void InitFunction(TableFunction& read_vertices) {
 // GetFunction
 //-------------------------------------------------------------------
 TableFunction ReadVertices::GetFunction() {
-    TableFunction read_vertices(GetFunctionName(), {LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction read_vertices(Identifier(GetFunctionName()), {LogicalType::VARCHAR}, Execute, Bind);
     InitFunction(read_vertices);
 
     read_vertices.named_parameters["type"] = LogicalType::VARCHAR;
@@ -209,7 +209,7 @@ TableFunction ReadVertices::GetFunction() {
 // GetScanFunction
 //-------------------------------------------------------------------
 TableFunction ReadVertices::GetScanFunction() {
-    TableFunction read_vertices({}, Execute, Bind);
+    TableFunction read_vertices("", {LogicalType::VARCHAR}, Execute, Bind);
     InitFunction(read_vertices);
 
     return read_vertices;

--- a/src/functions/table/shortest_path.cpp
+++ b/src/functions/table/shortest_path.cpp
@@ -77,11 +77,13 @@ unique_ptr<FunctionData> ShortestPath::Bind(ClientContext& context, TableFunctio
                                  ", end=" + std::to_string(bind_data->end_id) + ", table=" + table_name);
 
         auto qname = QualifiedName::Parse(table_name);
-        Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+        auto catalog_name = qname.Catalog();
+        auto schema_name = qname.Schema();
+        Binder::BindSchemaOrCatalog(context, catalog_name, schema_name);
 
-        auto& entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, qname.catalog, qname.schema, qname.name);
+        auto& entry = Catalog::GetEntry(context, CatalogType::TABLE_ENTRY, catalog_name, schema_name, qname.Name());
 
-        auto& table_entry = entry.Cast<GraphArTableEntry>();
+        auto& table_entry = entry.template Cast<GraphArTableEntry>();
         auto table_info = table_entry.GetTableInfo();
         if (table_info == nullptr) {
             throw InvalidInputException("Table info for '" + table_name + "' is expired.");
@@ -298,8 +300,8 @@ void ShortestPath::Function(ClientContext& context, TableFunctionInput& data_p, 
     step_vector.SetVectorType(VectorType::FLAT_VECTOR);
     vertex_vector.SetVectorType(VectorType::FLAT_VECTOR);
 
-    auto step_data = FlatVector::GetData<int64_t>(step_vector);
-    auto vertex_data = FlatVector::GetData<int64_t>(vertex_vector);
+    auto step_data = FlatVector::GetDataMutable<int64_t>(step_vector);
+    auto vertex_data = FlatVector::GetDataMutable<int64_t>(vertex_vector);
 
     step_data[0] = static_cast<int64_t>(global_state.current_step);
     vertex_data[0] = static_cast<int64_t>(global_state.path[global_state.current_step]);
@@ -311,7 +313,7 @@ TableFunction ShortestPath::GetFunction() {
     // Supports two signatures:
     // 1. shortest_path(start_id, end_id, edge_table_name) - uses catalog lookup
     // 2. shortest_path(start_id, end_id, graph_path, src=..., type=..., dst=...) - uses YAML path
-    TableFunction func("shortest_path", {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR}, Function,
+    TableFunction func(Identifier("shortest_path"), {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR}, Function,
                        Bind, InitGlobal);
     func.named_parameters["src"] = LogicalType::VARCHAR;
     func.named_parameters["type"] = LogicalType::VARCHAR;

--- a/src/functions/table/shortest_path.cpp
+++ b/src/functions/table/shortest_path.cpp
@@ -313,8 +313,8 @@ TableFunction ShortestPath::GetFunction() {
     // Supports two signatures:
     // 1. shortest_path(start_id, end_id, edge_table_name) - uses catalog lookup
     // 2. shortest_path(start_id, end_id, graph_path, src=..., type=..., dst=...) - uses YAML path
-    TableFunction func(Identifier("shortest_path"), {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR}, Function,
-                       Bind, InitGlobal);
+    TableFunction func(Identifier("shortest_path"), {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR},
+                       Function, Bind, InitGlobal);
     func.named_parameters["src"] = LogicalType::VARCHAR;
     func.named_parameters["type"] = LogicalType::VARCHAR;
     func.named_parameters["dst"] = LogicalType::VARCHAR;

--- a/src/functions/table/two_hop.cpp
+++ b/src/functions/table/two_hop.cpp
@@ -112,9 +112,9 @@ void TwoHop::Execute(ClientContext& context, TableFunctionInput& input, DataChun
 // GetFunction
 //-------------------------------------------------------------------
 TableFunctionSet TwoHop::GetFunctions() {
-    TableFunctionSet two_hop(GetFunctionName());
+    TableFunctionSet two_hop((Identifier(GetFunctionName())));
 
-    TableFunction two_hop_default({LogicalType::VARCHAR}, Execute, Bind);
+    TableFunction two_hop_default("", {LogicalType::VARCHAR}, Execute, Bind);
     SetTableFuncionParams(two_hop_default);
     two_hop.AddFunction(two_hop_default);
 

--- a/src/storage/graphar_catalog.cpp
+++ b/src/storage/graphar_catalog.cpp
@@ -7,6 +7,7 @@
 
 #include <duckdb/catalog/catalog_search_path.hpp>
 #include <duckdb/common/exception/transaction_exception.hpp>
+#include <duckdb/common/identifier.hpp>
 #include <duckdb/parser/parsed_data/create_schema_info.hpp>
 #include <duckdb/parser/parsed_data/create_table_info.hpp>
 #include <duckdb/storage/database_size.hpp>
@@ -17,14 +18,14 @@
 namespace duckdb {
 GraphArCatalog::GraphArCatalog(AttachedDatabase& db_p, const std::string& path_,
                                std::shared_ptr<graphar::GraphInfo>& graph_info_, ClientContext& context,
-                               std::string& database_name)
+                               const std::string& database_name)
     : Catalog(db_p),
       path(path_),
       graph_info(graph_info_),
       client_data(ClientData::Get(context)),
       database_name(database_name) {
     DUCKDB_GRAPHAR_LOG_TRACE("GraphArCatalog::GraphArCatalog");
-    CatalogSearchEntry entry(database_name, "main");
+    CatalogSearchEntry entry(Identifier(database_name), Identifier("main"));
     client_data.catalog_search_path->Set({entry}, CatalogSetPathType::SET_DIRECTLY);
 }
 

--- a/src/storage/graphar_schema_entry.cpp
+++ b/src/storage/graphar_schema_entry.cpp
@@ -45,10 +45,10 @@ optional_ptr<CatalogEntry> GraphArSchemaEntry::CreateFunction(CatalogTransaction
 }
 
 void GraphArUnqualifyColumnRef(ParsedExpression& expr) {
-    if (expr.type == ExpressionType::COLUMN_REF) {
+    if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
         auto& colref = expr.Cast<ColumnRefExpression>();
-        auto name = std::move(colref.column_names.back());
-        colref.column_names = {std::move(name)};
+        auto name = std::move(colref.ColumnNamesMutable().back());
+        colref.ColumnNamesMutable() = {std::move(name)};
         return;
     }
     ParsedExpressionIterator::EnumerateChildren(expr, GraphArUnqualifyColumnRef);

--- a/src/storage/graphar_storage.cpp
+++ b/src/storage/graphar_storage.cpp
@@ -58,7 +58,7 @@ static unique_ptr<Catalog> GraphArAttach(optional_ptr<StorageExtensionInfo> stor
             }
         }
     }
-    return make_uniq<GraphArCatalog>(db, info.path, graph_info, context, db.name);
+    return make_uniq<GraphArCatalog>(db, info.path, graph_info, context, name);
 }
 
 static unique_ptr<TransactionManager> GraphArCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/storage/graphar_table_set.cpp
+++ b/src/storage/graphar_table_set.cpp
@@ -56,7 +56,7 @@ optional_ptr<CatalogEntry> GraphArTableSet::CreateNewEntry(ClientContext& contex
 optional_ptr<CatalogEntry> GraphArTableSet::CreateNewEntry(ClientContext& context, Catalog& catalog,
                                                            GraphArSchemaEntry& schema, CreateViewInfo& info) {
     auto view = make_shared_ptr<ViewCatalogEntry>(catalog, schema, info);
-    const auto& view_name = info.view_name;
+    const auto& view_name = info.GetViewName().GetIdentifierName();
     view_entries[view_name] = view;
     DUCKDB_GRAPHAR_LOG_INFO("View was created with name " + view_name);
     return view.get();
@@ -72,7 +72,7 @@ GraphArTableSet::CreateTables(GraphArCatalog& graphar_catalog, const InfoVector&
         auto create_table_info = make_uniq<CreateTableInfo>();
         create_table_info->tags["type"] = (type == GraphArTableType::Vertex) ? "vertex" : "edge";
         auto file_name = GraphArFunctions::GetNameFromInfo(info);
-        create_table_info->table = file_name;
+        create_table_info->SetTableName(Identifier(file_name));
 
         auto bind_data = make_uniq<ReadBindData>();
         auto& graphar_catalog = catalog.Cast<GraphArCatalog>();
@@ -84,7 +84,7 @@ GraphArTableSet::CreateTables(GraphArCatalog& graphar_catalog, const InfoVector&
 
         vector<ColumnDefinition> columns;
         for (idx_t i = 0; i < bind_data->GetFlattenPropNames().size(); ++i) {
-            columns.emplace_back(bind_data->GetFlattenPropNames()[i],
+            columns.emplace_back(Identifier(bind_data->GetFlattenPropNames()[i]),
                                  GraphArFunctions::graphArT2duckT(bind_data->GetFlattenPropTypes()[i]));
         }
         create_table_info->columns = ColumnList(std::move(columns));

--- a/src/utils/func.cpp
+++ b/src/utils/func.cpp
@@ -179,7 +179,6 @@ void ConvertArrowTableToDataChunk(const arrow::Table& table, DataChunk& output, 
     }
 
     const auto num_rows = table.num_rows();
-    output.SetCapacity(num_rows);
     output.SetCardinality(num_rows);
     for (idx_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
         auto& arrow_type = *arrow_table_schema.GetColumns().at(column_ids[col_idx]);

--- a/src/utils/global_log_manager.cpp
+++ b/src/utils/global_log_manager.cpp
@@ -2,13 +2,12 @@
 
 namespace duckdb {
 
-std::optional<std::reference_wrapper<LogManager>> GlobalLogManager::log_manager = std::nullopt;
+LogManager* GlobalLogManager::log_manager = nullptr;
 
 void GlobalLogManager::Initialize(DatabaseInstance& db, LogLevel log_level) {
-    log_manager = db.GetLogManager();
-    LogManager& log_manager_ref = log_manager->get();
-    log_manager_ref.SetEnableLogging(true);
-    log_manager_ref.SetLogStorage(db, "stdout");
-    log_manager_ref.SetLogLevel(log_level);
+    log_manager = &db.GetLogManager();
+    log_manager->SetEnableLogging(true);
+    log_manager->SetLogStorage(db, "stdout");
+    log_manager->SetLogLevel(log_level);
 }
 }  // namespace duckdb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,9 +28,9 @@ target_link_libraries(unittest_graphar
         Catch2::Catch2WithMain
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_libraries(unittest_graphar PRIVATE jemalloc_extension)
-endif()
+# jemalloc is now built into DuckDB core (ENABLE_JEMALLOC), not a separate extension
+# The jemalloc_extension target is only created as an empty INTERFACE for backward compatibility
+# when jemalloc is explicitly listed in BUILD_EXTENSIONS, so we should not unconditionally link it
 
 target_include_directories(unittest_graphar PRIVATE
     ${DUCKDB_INCLUDES}

--- a/tests/table_functions/table_functions_fixture.hpp
+++ b/tests/table_functions/table_functions_fixture.hpp
@@ -25,7 +25,7 @@ protected:
     std::string folder_feature_graph;
     
     static duckdb::TableFunctionBindInput CreateMockBindInput(duckdb::vector<duckdb::Value> &inputs, duckdb::named_parameter_map_t &named_parameters, duckdb::vector<duckdb::LogicalType> &input_table_types) {
-        duckdb::vector<std::string> input_table_names;
+        duckdb::vector<duckdb::Identifier> input_table_names;
         duckdb::TableFunction table_function;
         duckdb::TableFunctionRef ref;
 

--- a/tests/table_functions/test_read_edges.cpp
+++ b/tests/table_functions/test_read_edges.cpp
@@ -97,7 +97,7 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges Bind and Execute fun
     REQUIRE_NOTHROW(read_edges.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
         INFO("Size of the result part: " << tmp.size());
-        REQUIRE_NOTHROW(res.Append(tmp, true));
+        REQUIRE_NOTHROW(res.Append(tmp, VectorAppendMode::ALLOW_RESIZE));
         tmp.Reset();
         REQUIRE_NOTHROW(read_edges.function(*TestFixture::conn.context, func_input, tmp));
     }
@@ -195,7 +195,7 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadEdges Bind and Execute fun
     REQUIRE_NOTHROW(read_edges.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
         INFO("Size of the result part: " << tmp.size());
-        REQUIRE_NOTHROW(res.Append(tmp, true));
+        REQUIRE_NOTHROW(res.Append(tmp, VectorAppendMode::ALLOW_RESIZE));
 
         tmp.Reset();
         REQUIRE_NOTHROW(read_edges.function(*TestFixture::conn.context, func_input, tmp));

--- a/tests/table_functions/test_read_vertices.cpp
+++ b/tests/table_functions/test_read_vertices.cpp
@@ -72,7 +72,7 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ReadVertices Bind and Execute 
     REQUIRE_NOTHROW(read_vertices.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
         INFO("Size of the result part: " << tmp.size());
-        REQUIRE_NOTHROW(res.Append(tmp, true));
+        REQUIRE_NOTHROW(res.Append(tmp, VectorAppendMode::ALLOW_RESIZE));
         tmp.Reset();
         REQUIRE_NOTHROW(read_vertices.function(*TestFixture::conn.context, func_input, tmp));
     }

--- a/tests/table_functions/test_shortest_path.cpp
+++ b/tests/table_functions/test_shortest_path.cpp
@@ -95,11 +95,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 2); // step 0: vertex 1, step 1: vertex 2
@@ -164,11 +164,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 3); // step 0: vertex 1, step 1: vertex 2, step 2: vertex 4
@@ -235,11 +235,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 1); // step 0: vertex 1
@@ -302,11 +302,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 0); // No path exists
@@ -363,11 +363,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 0); // No path exists between disconnected components
@@ -423,11 +423,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 3); // step 0: vertex 0, step 1: vertex 1, step 2: vertex 2
@@ -493,11 +493,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 0);
@@ -552,11 +552,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 0);
@@ -611,11 +611,11 @@ TEMPLATE_TEST_CASE_METHOD(TableFunctionsFixture, "ShortestPath Bind and Execute 
     INFO("Execute test");
     REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     while (tmp.size() > 0){
-        res.Append(tmp, true);
+        res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
         tmp.Reset();
         REQUIRE_NOTHROW(shortest_path_func.function(*TestFixture::conn.context, func_input, tmp));
     }
-    if(tmp.size() > 0) res.Append(tmp, true);
+    if(tmp.size() > 0) res.Append(tmp, VectorAppendMode::ALLOW_RESIZE);
 
     INFO("Checking results");
     REQUIRE(res.size() == 0);


### PR DESCRIPTION
This PR fixes critical issues in the hop functions and upgrades DuckDB from v1.5.1 to v1.6.0, requiring extensive API migration.

Key Changes:

1. Two Hop UDF Bug Fixes:

- Fixed bugs causing reading from non-existing files

2. DuckDB 1.6.0 API Migration:

- Updated catalog/schema binding to use Identifier wrapper
- Migrated filter handling to new BoundFunctionExpression API (BoundComparisonExpression::IsComparison, GetChildrenMutable())
- Updated TableFunction constructors to use Identifier for function names
- Replaced deprecated SetCapacity() with SetCardinality()/SetChildCardinality()
- Updated Append() to use VectorAppendMode::ALLOW_RESIZE enum
- Fixed FlatVector::GetData() → FlatVector::GetDataMutable()

3. Test Updates:
- Updated test paths to use {WORKING_DIRECTORY} placeholder
- Added LOAD parquet; statements where required